### PR TITLE
DBCP-476 Fixes race condition with WeakReference in clean up of Aband…

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/AbandonedTrace.java
+++ b/src/main/java/org/apache/commons/dbcp2/AbandonedTrace.java
@@ -134,12 +134,12 @@ public class AbandonedTrace implements TrackedUse {
         synchronized (this.traceList) {
             final Iterator<WeakReference<AbandonedTrace>> iter = traceList.iterator();
             while (iter.hasNext()) {
-                final WeakReference<AbandonedTrace> ref = iter.next();
-                if (ref.get() == null) {
+                final AbandonedTrace trace = iter.next().get();
+                if (trace == null) {
                     // Clean-up since we are here anyway
                     iter.remove();
                 } else {
-                    result.add(ref.get());
+                    result.add(trace);
                 }
             }
         }
@@ -155,11 +155,11 @@ public class AbandonedTrace implements TrackedUse {
         synchronized(this.traceList) {
             final Iterator<WeakReference<AbandonedTrace>> iter = traceList.iterator();
             while (iter.hasNext()) {
-                final WeakReference<AbandonedTrace> ref = iter.next();
-                if (trace.equals(ref.get())) {
+                final AbandonedTrace traceInList = iter.next().get();
+                if (trace.equals(traceInList)) {
                     iter.remove();
                     break;
-                } else if (ref.get() == null) {
+                } else if (traceInList == null) {
                     // Clean-up since we are here anyway
                     iter.remove();
                 }


### PR DESCRIPTION
The usage of WeakReference here opens the possibility of a race condition where the WeakReference is collected after it has been tested. We have been experiencing NPE's caused due to the race.