### PR TITLE
WIP: Update Apache Commons Pool to 2.4.3 and fix unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
     <commons.scm-publish.version>1.1</commons.scm-publish.version>
     <commons.checkstyle.version>2.11</commons.checkstyle.version>
     <!-- Constant for Commons Pool version (used in multiple places) -->
-    <commons.pool.version>2.4.2</commons.pool.version>
+    <commons.pool.version>2.4.3</commons.pool.version>
     <!-- See DBCP-445 and DBCP-454 -->
     <commons.osgi.import>javax.transaction;version="1.1.0",javax.transaction.xa;version="1.1.0";partial=true;mandatory:=partial,*</commons.osgi.import>
 

--- a/src/test/java/org/apache/commons/dbcp2/TestAbandonedBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestAbandonedBasicDataSource.java
@@ -97,7 +97,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
         conn1.close();
         assertEquals(0, ds.getNumActive());
         final String string = sw.toString();
-        assertTrue(string, string.contains("testAbandonedClose"));
+        assertTrue(string, string.contains(TestAbandonedBasicDataSource.class.getName()));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
         }
         assertEquals(0, ds.getNumActive());
         final String string = sw.toString();
-        assertTrue(string, string.contains("testAbandonedCloseWithExceptions"));
+        assertTrue(string, string.contains(TestAbandonedBasicDataSource.class.getName()));
     }
 
     /**


### PR DESCRIPTION
Updated in pom.xml to pool 2.4.3. Started the tests in Maven command line, found which tests failed. Executed the tests in Eclipse, found which class was related to the failure. Then did a diff between both tags.

    git diff POOL_2_4_2 POOL_2.4.3-RC1 -- ./src/main/java/org/apache/commons/pool2/impl/DefaultPooledObject.java

The short diff indicates that the failures started possibly due to the replacement of Exceptions in the DefaultPooledObject by a CallStack. The CallStack seems to not keep track of all the methods (due to a security context manager from what I could tell).