### PR TITLE
WIP DBCP-509: Consistency across methods in PerUserPooldataSource and its parent

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/datasources/InstanceKeyDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/datasources/InstanceKeyDataSource.java
@@ -134,9 +134,9 @@ public abstract class InstanceKeyDataSource implements DataSource, Referenceable
     private long maxConnLifetimeMillis = -1;
 
     // Connection properties
-    private Boolean defaultAutoCommit;
+    private boolean defaultAutoCommit;
     private int defaultTransactionIsolation = UNKNOWN_TRANSACTIONISOLATION;
-    private Boolean defaultReadOnly;
+    private boolean defaultReadOnly;
 
     /**
      * Default no-arg constructor for Serialization
@@ -585,7 +585,7 @@ public abstract class InstanceKeyDataSource implements DataSource, Referenceable
      *
      * @return value of defaultAutoCommit.
      */
-    public Boolean isDefaultAutoCommit() {
+    public boolean isDefaultAutoCommit() {
         return defaultAutoCommit;
     }
 
@@ -597,7 +597,7 @@ public abstract class InstanceKeyDataSource implements DataSource, Referenceable
      * @param v
      *            Value to assign to defaultAutoCommit.
      */
-    public void setDefaultAutoCommit(final Boolean v) {
+    public void setDefaultAutoCommit(final boolean v) {
         assertInitializationAllowed();
         this.defaultAutoCommit = v;
     }
@@ -609,7 +609,7 @@ public abstract class InstanceKeyDataSource implements DataSource, Referenceable
      *
      * @return value of defaultReadOnly.
      */
-    public Boolean isDefaultReadOnly() {
+    public boolean isDefaultReadOnly() {
         return defaultReadOnly;
     }
 
@@ -621,7 +621,7 @@ public abstract class InstanceKeyDataSource implements DataSource, Referenceable
      * @param v
      *            Value to assign to defaultReadOnly.
      */
-    public void setDefaultReadOnly(final Boolean v) {
+    public void setDefaultReadOnly(final boolean v) {
         assertInitializationAllowed();
         this.defaultReadOnly = v;
     }

--- a/src/main/java/org/apache/commons/dbcp2/datasources/PerUserPoolDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/datasources/PerUserPoolDataSource.java
@@ -211,12 +211,15 @@ public class PerUserPoolDataSource extends InstanceKeyDataSource {
      *            The user name key.
      * @return The user specific value.
      */
-    public Boolean getPerUserDefaultAutoCommit(final String userName) {
+    public boolean getPerUserDefaultAutoCommit(final String userName) {
         Boolean value = null;
         if (perUserDefaultAutoCommit != null) {
             value = perUserDefaultAutoCommit.get(userName);
         }
-        return value;
+        if (value == null) {
+            return isDefaultAutoCommit();
+        }
+        return value.booleanValue();
     }
 
     /**
@@ -226,12 +229,15 @@ public class PerUserPoolDataSource extends InstanceKeyDataSource {
      *            The user name key.
      * @return The user specific value.
      */
-    public Boolean getPerUserDefaultReadOnly(final String userName) {
+    public boolean getPerUserDefaultReadOnly(final String userName) {
         Boolean value = null;
         if (perUserDefaultReadOnly != null) {
             value = perUserDefaultReadOnly.get(userName);
         }
-        return value;
+        if (value == null) {
+            return isDefaultReadOnly();
+        }
+        return value.booleanValue();
     }
 
     /**
@@ -242,12 +248,15 @@ public class PerUserPoolDataSource extends InstanceKeyDataSource {
      *            The user name key.
      * @return The user specific value.
      */
-    public Integer getPerUserDefaultTransactionIsolation(final String userName) {
+    public int getPerUserDefaultTransactionIsolation(final String userName) {
         Integer value = null;
         if (perUserDefaultTransactionIsolation != null) {
             value = perUserDefaultTransactionIsolation.get(userName);
         }
-        return value;
+        if (value == null) {
+            return getDefaultTransactionIsolation();
+        }
+        return value.intValue();
     }
 
     /**


### PR DESCRIPTION
For discussion for DBCP-509. A proposal to use primitives and use the default values instead of nulls, as in the other methods.