### PR TITLE
DBCP-515 Added support for obtaining a reference to the connection du…

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/managed/TransactionContext.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/TransactionContext.java
@@ -130,6 +130,16 @@ public class TransactionContext {
      */
     public void addTransactionContextListener(final TransactionContextListener listener) throws SQLException {
         try {
+            if (!isActive()) {
+                Transaction transaction = this.transactionRef.get();
+                if (transaction == null) {
+                    listener.afterCompletion(TransactionContext.this, false);
+                } else {
+                    final int status = transaction.getStatus();
+                    listener.afterCompletion(TransactionContext.this, status == Status.STATUS_COMMITTED);
+                }
+                return;
+            }
             final Synchronization s = new Synchronization() {
                 @Override
                 public void beforeCompletion() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/DBCP-515

Should be merged with https://github.com/apache/commons-dbcp/pull/17 ideally to ensure that the connection is not double returned to the pool during checkOpen and similar (existing bug)