### PR TITLE
Upgrade to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,9 +180,16 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.4.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -224,8 +231,8 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
-          <artifactId>junit</artifactId>
-          <groupId>junit</groupId>
+          <artifactId>org.junit.jupiter</artifactId>
+          <groupId>junit-jupiter</groupId>
         </exclusion>
         <exclusion>
           <artifactId>commons-logging</artifactId>

--- a/src/test/java/org/apache/commons/dbcp2/TestAbandonedBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestAbandonedBasicDataSource.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -31,9 +31,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for BasicDataSource with abandoned connection trace enabled
@@ -43,7 +43,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
     private StringWriter sw;
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         // abandoned enabled but should not affect the basic tests
@@ -95,7 +95,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
         conn1.close();
         assertEquals(0, ds.getNumActive());
         final String string = sw.toString();
-        assertTrue(string, string.contains("testAbandonedClose"));
+        assertTrue(string.contains("testAbandonedClose"), string);
     }
 
     @Test
@@ -132,7 +132,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
         }
         assertEquals(0, ds.getNumActive());
         final String string = sw.toString();
-        assertTrue(string, string.contains("testAbandonedCloseWithExceptions"));
+        assertTrue(string.contains("testAbandonedCloseWithExceptions"), string);
     }
 
     /**
@@ -193,10 +193,10 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
                 Statement st = conn1.createStatement()) {
             final String querySQL = "SELECT 1 FROM DUAL";
             Thread.sleep(500);
-            Assert.assertNotNull(st.executeQuery(querySQL)); // Should reset lastUsed
+            Assertions.assertNotNull(st.executeQuery(querySQL)); // Should reset lastUsed
             Thread.sleep(800);
             final Connection conn2 = ds.getConnection(); // triggers abandoned cleanup
-            Assert.assertNotNull(st.executeQuery(querySQL)); // Should still be OK
+            Assertions.assertNotNull(st.executeQuery(querySQL)); // Should still be OK
             conn2.close();
             Thread.sleep(500);
             st.executeUpdate(""); // Should also reset
@@ -218,10 +218,10 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
                 Statement st = conn1.createStatement()) {
             final String querySQL = "SELECT 1 FROM DUAL";
             Thread.sleep(500);
-            Assert.assertNotNull(st.executeQuery(querySQL)); // Should reset lastUsed
+            Assertions.assertNotNull(st.executeQuery(querySQL)); // Should reset lastUsed
             Thread.sleep(800);
             final Connection conn2 = ds.getConnection(); // triggers abandoned cleanup
-            Assert.assertNotNull(st.executeQuery(querySQL)); // Should still be OK
+            Assertions.assertNotNull(st.executeQuery(querySQL)); // Should still be OK
             conn2.close();
             Thread.sleep(500);
             st.executeLargeUpdate(""); // Should also reset
@@ -256,11 +256,11 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
     @Test
     public void testGarbageCollectorCleanUp01() throws Exception {
         final DelegatingConnection<?> conn = (DelegatingConnection<?>) ds.getConnection();
-        Assert.assertEquals(0, conn.getTrace().size());
+        Assertions.assertEquals(0, conn.getTrace().size());
         createStatement(conn);
-        Assert.assertEquals(1, conn.getTrace().size());
+        Assertions.assertEquals(1, conn.getTrace().size());
         System.gc();
-        Assert.assertEquals(0, conn.getTrace().size());
+        Assertions.assertEquals(0, conn.getTrace().size());
     }
 
     /**
@@ -277,11 +277,11 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
         final
         GenericKeyedObjectPool<PStmtKey, DelegatingPreparedStatement>  gkop =
                 (GenericKeyedObjectPool<PStmtKey, DelegatingPreparedStatement>) TesterUtils.getField(poolingConn, "pstmtPool");
-        Assert.assertEquals(0, conn.getTrace().size());
-        Assert.assertEquals(0, gkop.getNumActive());
+        Assertions.assertEquals(0, conn.getTrace().size());
+        Assertions.assertEquals(0, gkop.getNumActive());
         createStatement(conn);
-        Assert.assertEquals(1, conn.getTrace().size());
-        Assert.assertEquals(1, gkop.getNumActive());
+        Assertions.assertEquals(1, conn.getTrace().size());
+        Assertions.assertEquals(1, gkop.getNumActive());
         System.gc();
         // Finalization happens in a separate thread. Give the test time for
         // that to complete.
@@ -290,13 +290,13 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
             Thread.sleep(100);
             count++;
         }
-        Assert.assertEquals(0, gkop.getNumActive());
-        Assert.assertEquals(0, conn.getTrace().size());
+        Assertions.assertEquals(0, gkop.getNumActive());
+        Assertions.assertEquals(0, conn.getTrace().size());
     }
 
     private void createStatement(final Connection conn) throws Exception{
         final PreparedStatement ps = conn.prepareStatement("");
-        Assert.assertNotNull(ps);
+        Assertions.assertNotNull(ps);
     }
 
 
@@ -314,7 +314,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
         assertAndReset(conn);
         st.executeLargeBatch();
         assertAndReset(conn);
-        Assert.assertNotNull(st.executeQuery(""));
+        Assertions.assertNotNull(st.executeQuery(""));
         assertAndReset(conn);
         st.executeUpdate("");
         assertAndReset(conn);
@@ -338,7 +338,7 @@ public class TestAbandonedBasicDataSource extends TestBasicDataSource {
     private void checkLastUsedPreparedStatement(final PreparedStatement ps, final DelegatingConnection<?> conn) throws Exception {
         ps.execute();
         assertAndReset(conn);
-        Assert.assertNotNull(ps.executeQuery());
+        Assertions.assertNotNull(ps.executeQuery());
         assertAndReset(conn);
         ps.executeUpdate();
         assertAndReset(conn);

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -17,7 +17,8 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -35,11 +36,11 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.LogFactory;
 import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for BasicDataSource
@@ -54,13 +55,13 @@ public class TestBasicDataSource extends TestConnectionPool {
     protected BasicDataSource ds = null;
     private static final String CATALOG = "test catalog";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         // register a custom logger which supports inspection of the log messages
         LogFactory.getFactory().setAttribute("org.apache.commons.logging.Log", "org.apache.commons.dbcp2.StackMessageLog");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ds = createDataSource();
         ds.setDriverClassName("org.apache.commons.dbcp2.TesterDriver");
@@ -84,7 +85,7 @@ public class TestBasicDataSource extends TestConnectionPool {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         super.tearDown();
         ds.close();
@@ -464,7 +465,7 @@ public class TestBasicDataSource extends TestConnectionPool {
             ds.close();
             // Exception must have been swallowed by the pool - verify it is logged
             final String message = StackMessageLog.popMessage();
-            Assert.assertNotNull(message);
+            Assertions.assertNotNull(message);
             assertTrue(message.indexOf("bang") > 0);
         } catch (final SQLException ex) {
             assertTrue(ex.getMessage().indexOf("Cannot close") > 0);
@@ -487,7 +488,7 @@ public class TestBasicDataSource extends TestConnectionPool {
             StackMessageLog.clear();
             ds.close();
             final String message = StackMessageLog.popMessage();
-            Assert.assertNotNull(message);
+            Assertions.assertNotNull(message);
             assertTrue(message.indexOf("boom") > 0);
         } catch (final IllegalStateException ex) {
             assertTrue(ex.getMessage().indexOf("boom") > 0); // RTE is not wrapped by BDS#close
@@ -698,7 +699,7 @@ public class TestBasicDataSource extends TestConnectionPool {
             conn.close();
             assertEquals(0, ds.getNumIdle());
             final String message = StackMessageLog.popMessage();
-            Assert.assertNotNull(message);
+            Assertions.assertNotNull(message);
             assertTrue(message.indexOf("exceeds the maximum permitted value") > 0);
         } finally {
             StackMessageLog.clear();
@@ -718,7 +719,7 @@ public class TestBasicDataSource extends TestConnectionPool {
                 Thread.sleep(500);
             }
             assertEquals(0, ds.getNumIdle());
-            assertTrue(StackMessageLog.getAll().toString(), StackMessageLog.isEmpty());
+            assertTrue(StackMessageLog.isEmpty(), StackMessageLog.getAll().toString());
         } finally {
             StackMessageLog.clear();
             StackMessageLog.unLock();
@@ -865,7 +866,7 @@ public class TestBasicDataSource extends TestConnectionPool {
         final BasicDataSource ds = BasicDataSourceFactory.createDataSource(properties);
         final boolean original = ds.getConnectionPool().getLogAbandoned();
         ds.setLogAbandoned(!original);
-        Assert.assertNotEquals(Boolean.valueOf(original),
+        Assertions.assertNotEquals(Boolean.valueOf(original),
                 Boolean.valueOf(ds.getConnectionPool().getLogAbandoned()));
     }
 }

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSourceFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSourceFactory.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.management.ManagementFactory;
 import java.sql.Connection;
@@ -33,7 +33,7 @@ import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for BasicDataSourceFactory
@@ -66,7 +66,7 @@ public class TestBasicDataSourceFactory {
             final BasicDataSourceFactory basicDataSourceFactory = new BasicDataSourceFactory();
             basicDataSourceFactory.getObjectInstance(ref, null, null, null);
             final List<String> messages = StackMessageLog.getAll();
-            assertEquals(messages.toString(), 2, messages.size());
+            assertEquals(2, messages.size(), messages.toString());
             for (final String message : messages) {
                 if (message.contains("maxWait")) {
                     assertTrue(message.contains("use maxWaitMillis"));

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSourceMXBean.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSourceMXBean.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for BasicDataSourceMXBean.

--- a/src/test/java/org/apache/commons/dbcp2/TestConnectionPool.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestConnectionPool.java
@@ -27,16 +27,16 @@ import java.util.Hashtable;
 import java.util.Random;
 import java.util.Stack;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 // XXX FIX ME XXX
 // this class still needs some cleanup, but at least
@@ -49,7 +49,7 @@ import static org.junit.Assert.fail;
  */
 public abstract class TestConnectionPool {
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         // Close any connections opened by the test
         while (!connections.isEmpty()) {
@@ -281,31 +281,31 @@ public abstract class TestConnectionPool {
         assertFalse(conn.isClosed());
         assertFalse(isClosed(statement));
 
-        assertSame("statement.getConnection() should return the exact same connection instance that was used to create the statement",
-                conn, statement.getConnection());
+        assertSame(conn,statement.getConnection(),
+                "statement.getConnection() should return the exact same connection instance that was used to create the statement");
 
         final ResultSet resultSet = statement.getResultSet();
         assertFalse(isClosed(resultSet));
-        assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                statement, resultSet.getStatement());
+        assertSame(statement, resultSet.getStatement(),
+                "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
 
         final ResultSet executeResultSet = statement.executeQuery("select * from dual");
         assertFalse(isClosed(executeResultSet));
-        assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                statement, executeResultSet.getStatement());
+        assertSame(statement, executeResultSet.getStatement(),
+                "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
 
         final ResultSet keysResultSet = statement.getGeneratedKeys();
         assertFalse(isClosed(keysResultSet));
-        assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                statement, keysResultSet.getStatement());
+        assertSame(statement, keysResultSet.getStatement(),
+                "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
 
         ResultSet preparedResultSet = null;
         if (statement instanceof PreparedStatement) {
             final PreparedStatement preparedStatement = (PreparedStatement) statement;
             preparedResultSet = preparedStatement.executeQuery();
             assertFalse(isClosed(preparedResultSet));
-            assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                    statement, preparedResultSet.getStatement());
+            assertSame(statement, preparedResultSet.getStatement(),
+                    "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
         }
 
 
@@ -426,7 +426,7 @@ public abstract class TestConnectionPool {
             final Connection con = newConnection();
             final Connection underCon =
                 ((DelegatingConnection<?>) con).getInnermostDelegate();
-            assertTrue("Failed to get connection", underCon != null);
+            assertTrue(underCon != null, "Failed to get connection");
             boolean found = false;
             for (int j = 0; j < c.length; j++) {
                 if (underCon == u[j]) {
@@ -434,7 +434,7 @@ public abstract class TestConnectionPool {
                     break;
                 }
             }
-            assertTrue("New connection not from pool", found);
+            assertTrue(found, "New connection not from pool");
             con.close();
         }
     }
@@ -442,23 +442,23 @@ public abstract class TestConnectionPool {
     @Test
     public void testAutoCommitBehavior() throws Exception {
         final Connection conn0 = newConnection();
-        assertNotNull("connection should not be null", conn0);
-        assertTrue("autocommit should be true for conn0", conn0.getAutoCommit());
+        assertNotNull(conn0, "connection should not be null");
+        assertTrue(conn0.getAutoCommit(), "autocommit should be true for conn0");
 
         final Connection conn1 = newConnection();
-        assertTrue("autocommit should be true for conn1", conn1.getAutoCommit() );
+        assertTrue(conn1.getAutoCommit(), "autocommit should be true for conn1");
         conn1.close();
 
-        assertTrue("autocommit should be true for conn0", conn0.getAutoCommit());
+        assertTrue(conn0.getAutoCommit(), "autocommit should be true for conn0");
         conn0.setAutoCommit(false);
-        assertFalse("autocommit should be false for conn0", conn0.getAutoCommit());
+        assertFalse(conn0.getAutoCommit(), "autocommit should be false for conn0");
         conn0.close();
 
         final Connection conn2 = newConnection();
-        assertTrue("autocommit should be true for conn2", conn2.getAutoCommit() );
+        assertTrue(conn2.getAutoCommit(), "autocommit should be true for conn2");
 
         final Connection conn3 = newConnection();
-        assertTrue("autocommit should be true for conn3", conn3.getAutoCommit() );
+        assertTrue(conn3.getAutoCommit(), "autocommit should be true for conn3");
 
         conn2.close();
 
@@ -844,11 +844,11 @@ public abstract class TestConnectionPool {
                         System.out.println("NOTE: some threads did not run the code: "+didNotRun);
                     }
                     // Perform initial sanity check:
-                    assertTrue("Expected some of the threads to fail",failed > 0);
+                    assertTrue(failed > 0, "Expected some of the threads to fail");
                     // Assume that threads that did not run would have timed out.
-                    assertEquals("WARNING: Expected half the threads to fail",pts.length/2,failed+didNotRun);
+                    assertEquals(pts.length/2, failed+didNotRun, "WARNING: Expected half the threads to fail");
                 } else {
-                    assertEquals("Did not expect any threads to fail",0,failed);
+                    assertEquals(0, failed, "Did not expect any threads to fail");
                 }
             }
     private static int currentThreadCount = 0;

--- a/src/test/java/org/apache/commons/dbcp2/TestConstants.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestConstants.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Constants.

--- a/src/test/java/org/apache/commons/dbcp2/TestDataSourceConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDataSourceConnectionFactory.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.PrintWriter;
 import java.sql.Connection;
@@ -28,8 +28,8 @@ import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for DataSourceConnectionFactory.
@@ -39,7 +39,7 @@ public class TestDataSourceConnectionFactory {
     private DataSource datasource;
     private DataSourceConnectionFactory factory;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         datasource = new TestDataSource();
         factory = new DataSourceConnectionFactory(datasource);

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingCallableStatement.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingCallableStatement.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,8 +28,8 @@ import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "deprecation", "unchecked", "rawtypes" }) // BigDecimal methods, and casting for mocks
 public class TestDelegatingCallableStatement {
@@ -38,7 +38,7 @@ public class TestDelegatingCallableStatement {
     private DelegatingCallableStatement delegate = null;
     private CallableStatement obj = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         conn = new TesterConnection("test", "test");
         obj = mock(CallableStatement.class);

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingConnection.java
@@ -17,19 +17,19 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -39,7 +39,7 @@ public class TestDelegatingConnection {
     private Connection delegateConn = null;
     private Connection delegateConn2 = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         delegateConn = new TesterConnection("test", "test");
         delegateConn2 = new TesterConnection("test", "test");

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingDatabaseMetaData.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingDatabaseMetaData.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,8 +29,8 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test suite for {@link DelegatingDatabaseMetaData}.
@@ -42,7 +42,7 @@ public class TestDelegatingDatabaseMetaData {
     private DelegatingDatabaseMetaData delegate = null;
     private DatabaseMetaData obj = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         obj = mock(DatabaseMetaData.class);
         testConn = new TesterConnection("test", "test");

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingPreparedStatement.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingPreparedStatement.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.verify;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({ "deprecation", "rawtypes" }) // BigDecimal methods, and casting for mocks
 public class TestDelegatingPreparedStatement {
@@ -38,7 +38,7 @@ public class TestDelegatingPreparedStatement {
     private PreparedStatement obj = null;
     private DelegatingPreparedStatement delegate = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         testerConn = new TesterConnection("test", "test");
         connection = new DelegatingConnection<>(testerConn);

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingResultSet.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingResultSet.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,9 +29,9 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for DelegatingResultSet.
@@ -44,7 +44,7 @@ public class TestDelegatingResultSet {
     private ResultSet rs;
     private DelegatingResultSet delegate;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         testConn = new TesterConnection("foo", "bar");
         conn = new DelegatingConnection<>(testConn);
@@ -179,7 +179,7 @@ public class TestDelegatingResultSet {
     }
 
     // FIXME: this appears to be a bug
-    @Ignore
+    @Disabled
     @Test
     public void testGetBigDecimalStringInteger() throws Exception {
         try {
@@ -190,7 +190,7 @@ public class TestDelegatingResultSet {
     }
 
     // FIXME: this appears to be a bug
-    @Ignore
+    @Disabled
     @Test
     public void testGetBigDecimalIntegerInteger() throws Exception {
         try {
@@ -1630,7 +1630,7 @@ public class TestDelegatingResultSet {
     }
 
     // FIXME this appears to be a bug
-    @Ignore
+    @Disabled
     @Test
     public void testUpdateObjectStringObjectInteger() throws Exception {
         try {
@@ -1641,7 +1641,7 @@ public class TestDelegatingResultSet {
     }
 
     // FIXME: this appears to be a bug
-    @Ignore
+    @Disabled
     @Test
     public void testUpdateObjectIntegerObjectInteger() throws Exception {
         try {

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingStatement.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingStatement.java
@@ -17,11 +17,11 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,8 +31,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestDelegatingStatement {
 
@@ -41,7 +41,7 @@ public class TestDelegatingStatement {
     private Statement obj = null;
     private DelegatingStatement delegate = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         delegateConn = new TesterConnection("test", "test");
         conn = new DelegatingConnection<>(delegateConn);

--- a/src/test/java/org/apache/commons/dbcp2/TestDriverConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDriverConnectionFactory.java
@@ -17,13 +17,13 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for DriverConnectionFactory.

--- a/src/test/java/org/apache/commons/dbcp2/TestDriverManagerConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDriverManagerConnectionFactory.java
@@ -17,7 +17,8 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -27,9 +28,9 @@ import javax.sql.DataSource;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test *must* execute before all other tests to be effective as it tests
@@ -40,12 +41,12 @@ public class TestDriverManagerConnectionFactory {
 
     private static final String KEY_JDBC_DRIVERS = "jdbc.drivers";
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(KEY_JDBC_DRIVERS, "org.apache.commons.dbcp2.TesterDriver");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty(KEY_JDBC_DRIVERS);
     }
@@ -67,22 +68,22 @@ public class TestDriverManagerConnectionFactory {
         testDriverManagerInit(false);
     }
 
-    @Test(expected=IndexOutOfBoundsException.class) // thrown by TestDriver due to missing user
-    public void testDriverManagerWithoutUser() throws SQLException {
+    @Test
+    public void testDriverManagerWithoutUser() {
         final DriverManagerConnectionFactory cf = new DriverManagerConnectionFactory("jdbc:apache:commons:testdriver", null, "pass");
-        cf.createConnection();
+        assertThrows(IndexOutOfBoundsException.class, cf::createConnection); // thrown by TestDriver due to missing user
     }
 
-    @Test(expected=SQLException.class) // thrown by TestDriver due to invalid password
-    public void testDriverManagerWithoutPassword() throws SQLException {
+    @Test
+    public void testDriverManagerWithoutPassword() {
         final DriverManagerConnectionFactory cf = new DriverManagerConnectionFactory("jdbc:apache:commons:testdriver", "user", (char[]) null);
-        cf.createConnection();
+        assertThrows(SQLException.class, cf::createConnection); // thrown by TestDriver due to invalid password
     }
 
-    @Test(expected=ArrayIndexOutOfBoundsException.class) // thrown by TestDriver due to missing user
-    public void testDriverManagerWithoutCredentials() throws SQLException {
+    @Test
+    public void testDriverManagerWithoutCredentials() {
         final DriverManagerConnectionFactory cf = new DriverManagerConnectionFactory("jdbc:apache:commons:testdriver", null,  (char[]) null);
-        cf.createConnection();
+        assertThrows(ArrayIndexOutOfBoundsException.class, cf::createConnection); // thrown by TestDriver due to missing user
     }
 
     @Test

--- a/src/test/java/org/apache/commons/dbcp2/TestJndi.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestJndi.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Hashtable;
 
@@ -28,9 +28,9 @@ import javax.sql.DataSource;
 
 import org.apache.commons.dbcp2.datasources.SharedPoolDataSource;
 import org.apache.commons.dbcp2.datasources.PerUserPoolDataSource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests JNID bind and lookup for DataSource implementations.
@@ -84,13 +84,13 @@ public class TestJndi {
         checkBind(dataSource);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         context = getInitialContext();
         context.createSubcontext(JNDI_SUBCONTEXT);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         context.unbind(JNDI_PATH);
         context.destroySubcontext(JNDI_SUBCONTEXT);

--- a/src/test/java/org/apache/commons/dbcp2/TestLifetimeExceededException.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestLifetimeExceededException.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for LifetimeExceededException.

--- a/src/test/java/org/apache/commons/dbcp2/TestListException.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestListException.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ListException.

--- a/src/test/java/org/apache/commons/dbcp2/TestPStmtKey.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPStmtKey.java
@@ -16,17 +16,17 @@
  */
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Statement;
 import java.util.Arrays;
 
 import org.apache.commons.dbcp2.PoolingConnection.StatementType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link PStmtKey}.
@@ -40,35 +40,35 @@ public class TestPStmtKey {
      */
     @Test
     public void testCtorDifferentSchema() {
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1"), new PStmtKey("sql", "catalog1", "schema2"));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1"), new PStmtKey("sql", "catalog1", "schema2"));
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0),
                 new PStmtKey("sql", "catalog1", "schema2", 0));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0),
                 new PStmtKey("sql", "catalog1", "schema2", 0, 0));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0),
                 new PStmtKey("sql", "catalog1", "schema2", 0, 0, 0));
         //
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null),
                 new PStmtKey("sql", "catalog1", "schema2", 0, 0, 0, null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog1", "schema2", 0, 0, 0, StatementType.PREPARED_STATEMENT));
         //
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, null),
                 new PStmtKey("sql", "catalog1", "schema2", 0, 0, null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog1", "schema2", 0, 0, StatementType.PREPARED_STATEMENT));
         //
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (int[]) null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (int[]) null),
                 new PStmtKey("sql", "catalog1", "schema2", (int[]) null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new int[1]),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new int[1]),
                 new PStmtKey("sql", "catalog1", "schema2", new int[1]));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (String[]) null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (String[]) null),
                 new PStmtKey("sql", "catalog1", "schema2", (String[]) null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }),
                 new PStmtKey("sql", "catalog1", "schema2", new String[] {"A" }));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog1", "schema2", StatementType.PREPARED_STATEMENT));
-        Assert.assertNotEquals(
+        Assertions.assertNotEquals(
                 new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT, Integer.MAX_VALUE),
                 new PStmtKey("sql", "catalog1", "schema2", StatementType.PREPARED_STATEMENT, Integer.MAX_VALUE));
     }
@@ -78,35 +78,35 @@ public class TestPStmtKey {
      */
     @Test
     public void testCtorDifferentCatalog() {
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1"), new PStmtKey("sql", "catalog2", "schema1"));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1"), new PStmtKey("sql", "catalog2", "schema1"));
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0),
                 new PStmtKey("sql", "catalog2", "schema1", 0));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0),
                 new PStmtKey("sql", "catalog2", "schema1", 0, 0));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0),
                 new PStmtKey("sql", "catalog2", "schema1", 0, 0, 0));
         //
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null),
                 new PStmtKey("sql", "catalog2", "schema1", 0, 0, 0, null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog2", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT));
         //
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, null),
                 new PStmtKey("sql", "catalog2", "schema1", 0, 0, null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog2", "schema1", 0, 0, StatementType.PREPARED_STATEMENT));
         //
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (int[]) null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (int[]) null),
                 new PStmtKey("sql", "catalog2", "schema1", (int[]) null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new int[1]),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new int[1]),
                 new PStmtKey("sql", "catalog2", "schema1", new int[1]));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (String[]) null),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", (String[]) null),
                 new PStmtKey("sql", "catalog2", "schema1", (String[]) null));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }),
                 new PStmtKey("sql", "catalog2", "schema1", new String[] {"A" }));
-        Assert.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT),
+        Assertions.assertNotEquals(new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog2", "schema1", StatementType.PREPARED_STATEMENT));
-        Assert.assertNotEquals(
+        Assertions.assertNotEquals(
                 new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT, Integer.MAX_VALUE),
                 new PStmtKey("sql", "catalog2", "schema1", StatementType.PREPARED_STATEMENT, Integer.MAX_VALUE));
     }
@@ -116,35 +116,35 @@ public class TestPStmtKey {
      */
     @Test
     public void testCtorEquals() {
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1"), new PStmtKey("sql", "catalog1", "schema1"));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1"), new PStmtKey("sql", "catalog1", "schema1"));
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0),
                 new PStmtKey("sql", "catalog1", "schema1", 0));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0),
                 new PStmtKey("sql", "catalog1", "schema1", 0, 0));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0),
                 new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0));
         //
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null),
                 new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, null));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog1", "schema1", 0, 0, 0, StatementType.PREPARED_STATEMENT));
         //
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, null),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, null),
                 new PStmtKey("sql", "catalog1", "schema1", 0, 0, null));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog1", "schema1", 0, 0, StatementType.PREPARED_STATEMENT));
         //
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", (int[]) null),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", (int[]) null),
                 new PStmtKey("sql", "catalog1", "schema1", (int[]) null));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", new int[1]),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", new int[1]),
                 new PStmtKey("sql", "catalog1", "schema1", new int[1]));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", (String[]) null),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", (String[]) null),
                 new PStmtKey("sql", "catalog1", "schema1", (String[]) null));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }),
                 new PStmtKey("sql", "catalog1", "schema1", new String[] {"A" }));
-        Assert.assertEquals(new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT),
+        Assertions.assertEquals(new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT),
                 new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT, Integer.MAX_VALUE),
                 new PStmtKey("sql", "catalog1", "schema1", StatementType.PREPARED_STATEMENT, Integer.MAX_VALUE));
     }
@@ -158,10 +158,10 @@ public class TestPStmtKey {
     public void testCtorStringStringArrayOfInts() {
         final int[] input = {0, 0 };
         final PStmtKey pStmtKey = new PStmtKey("", "", "", input);
-        Assert.assertArrayEquals(input, pStmtKey.getColumnIndexes());
+        Assertions.assertArrayEquals(input, pStmtKey.getColumnIndexes());
         input[0] = 1;
         input[1] = 1;
-        Assert.assertFalse(Arrays.equals(input, pStmtKey.getColumnIndexes()));
+        Assertions.assertFalse(Arrays.equals(input, pStmtKey.getColumnIndexes()));
     }
 
     /**
@@ -173,7 +173,7 @@ public class TestPStmtKey {
     public void testCtorStringStringArrayOfNullInts() {
         final int[] input = null;
         final PStmtKey pStmtKey = new PStmtKey("", "", "", input);
-        Assert.assertArrayEquals(input, pStmtKey.getColumnIndexes());
+        Assertions.assertArrayEquals(input, pStmtKey.getColumnIndexes());
     }
 
     /**
@@ -185,7 +185,7 @@ public class TestPStmtKey {
     public void testCtorStringStringArrayOfNullStrings() {
         final String[] input = null;
         final PStmtKey pStmtKey = new PStmtKey("", "", "", input);
-        Assert.assertArrayEquals(input, pStmtKey.getColumnNames());
+        Assertions.assertArrayEquals(input, pStmtKey.getColumnNames());
     }
 
     /**
@@ -197,10 +197,10 @@ public class TestPStmtKey {
     public void testCtorStringStringArrayOfStrings() {
         final String[] input = {"A", "B" };
         final PStmtKey pStmtKey = new PStmtKey("", "", "", input);
-        Assert.assertArrayEquals(input, pStmtKey.getColumnNames());
+        Assertions.assertArrayEquals(input, pStmtKey.getColumnNames());
         input[0] = "C";
         input[1] = "D";
-        Assert.assertFalse(Arrays.equals(input, pStmtKey.getColumnNames()));
+        Assertions.assertFalse(Arrays.equals(input, pStmtKey.getColumnNames()));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/dbcp2/TestPStmtPooling.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPStmtPooling.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -34,8 +34,8 @@ import javax.sql.DataSource;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for BasicDataSource with prepared statement pooling enabled
@@ -75,7 +75,7 @@ public class TestPStmtPooling {
        final Connection conn2 = ds.getConnection();
        final PreparedStatement stmt2 = conn2.prepareStatement("select 1 from dual");
        // Confirm stmt2 now wraps the same PPS wrapped by stmt1
-       Assert.assertSame(pps1, getPoolablePreparedStatement(stmt2));
+       Assertions.assertSame(pps1, getPoolablePreparedStatement(stmt2));
        stmt1.close(); // close should not cascade to PPS that stmt1 used to wrap
        assertTrue(!stmt2.isClosed());
        stmt2.executeQuery();  // wrapped PPS needs to work here - pre DBCP-414 fix this throws
@@ -220,7 +220,7 @@ public class TestPStmtPooling {
         ps.addBatch();
         ps.close();
         conn.close();
-        Assert.assertFalse(inner.isClosed());
+        Assertions.assertFalse(inner.isClosed());
         ds.close();
     }
 }

--- a/src/test/java/org/apache/commons/dbcp2/TestPStmtPoolingBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPStmtPoolingBasicDataSource.java
@@ -17,20 +17,20 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for BasicDataSource with prepared statement pooling enabled
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class TestPStmtPoolingBasicDataSource extends TestBasicDataSource {
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         // PoolPreparedStatements enabled, should not affect the basic tests

--- a/src/test/java/org/apache/commons/dbcp2/TestParallelCreationWithNoIdle.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestParallelCreationWithNoIdle.java
@@ -17,9 +17,9 @@
 package org.apache.commons.dbcp2;
 
 import org.apache.commons.logging.LogFactory;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test if the pooling if no idle objects are used
@@ -40,13 +40,13 @@ public class TestParallelCreationWithNoIdle  {
     protected BasicDataSource ds = null;
     private static final String CATALOG = "test catalog";
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         // register a custom logger which supports inspection of the log messages
         LogFactory.getFactory().setAttribute("org.apache.commons.logging.Log", "org.apache.commons.dbcp2.StackMessageLog");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ds = new BasicDataSource();
         ds.setDriverClassName("org.apache.commons.dbcp2.TesterConnectionDelayDriver");

--- a/src/test/java/org/apache/commons/dbcp2/TestPoolableConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPoolableConnection.java
@@ -16,19 +16,19 @@
  */
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -36,7 +36,7 @@ public class TestPoolableConnection {
 
     private GenericObjectPool<PoolableConnection> pool = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final PoolableConnectionFactory factory = new PoolableConnectionFactory(
                 new DriverConnectionFactory(
@@ -50,7 +50,7 @@ public class TestPoolableConnection {
         factory.setPool(pool);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         pool.close();
     }
@@ -60,13 +60,13 @@ public class TestPoolableConnection {
         // Grab a new connection from the pool
         final Connection c = pool.borrowObject();
 
-        assertNotNull("Connection should be created and should not be null", c);
-        assertEquals("There should be exactly one active object in the pool", 1, pool.getNumActive());
+        assertNotNull(c, "Connection should be created and should not be null");
+        assertEquals(1, pool.getNumActive(), "There should be exactly one active object in the pool");
 
         // Now return the connection by closing it
         c.close(); // Can't be null
 
-        assertEquals("There should now be zero active objects in the pool", 0, pool.getNumActive());
+        assertEquals(0, pool.getNumActive(), "There should now be zero active objects in the pool");
     }
 
     // Bugzilla Bug 33591: PoolableConnection leaks connections if the
@@ -92,27 +92,26 @@ public class TestPoolableConnection {
             // should *NOT* be returned to the pool
         }
 
-        assertEquals("The pool should have no active connections",
-            0, pool.getNumActive());
+        assertEquals(0, pool.getNumActive(), "The pool should have no active connections");
     }
 
     @Test
     public void testClosingWrappedInDelegate() throws Exception {
-        Assert.assertEquals(0, pool.getNumActive());
+        Assertions.assertEquals(0, pool.getNumActive());
 
         final Connection conn = pool.borrowObject();
         final DelegatingConnection<Connection> outer = new DelegatingConnection<>(conn);
 
-        Assert.assertFalse(outer.isClosed());
-        Assert.assertFalse(conn.isClosed());
-        Assert.assertEquals(1, pool.getNumActive());
+        Assertions.assertFalse(outer.isClosed());
+        Assertions.assertFalse(conn.isClosed());
+        Assertions.assertEquals(1, pool.getNumActive());
 
         outer.close();
 
-        Assert.assertTrue(outer.isClosed());
-        Assert.assertTrue(conn.isClosed());
-        Assert.assertEquals(0, pool.getNumActive());
-        Assert.assertEquals(1, pool.getNumIdle());
+        Assertions.assertTrue(outer.isClosed());
+        Assertions.assertTrue(conn.isClosed());
+        Assertions.assertEquals(0, pool.getNumActive());
+        Assertions.assertEquals(1, pool.getNumIdle());
     }
 
     @Test
@@ -157,10 +156,8 @@ public class TestPoolableConnection {
 
         // verify that bad connection does not get returned to the pool
         conn.close();  // testOnReturn triggers validate, which should fail
-        assertEquals("The pool should have no active connections",
-                0, pool.getNumActive());
-        assertEquals("The pool should have no idle connections",
-                0, pool.getNumIdle());
+        assertEquals(0, pool.getNumActive(), "The pool should have no active connections");
+        assertEquals(0, pool.getNumIdle(), "The pool should have no idle connections");
     }
 
     @Test
@@ -187,9 +184,7 @@ public class TestPoolableConnection {
 
         // verify that bad connection does not get returned to the pool
         conn.close();  // testOnReturn triggers validate, which should fail
-        assertEquals("The pool should have no active connections",
-                0, pool.getNumActive());
-        assertEquals("The pool should have no idle connections",
-                0, pool.getNumIdle());
+        assertEquals(0, pool.getNumActive(), "The pool should have no active connections");
+        assertEquals(0, pool.getNumIdle(), "The pool should have no idle connections");
     }
 }

--- a/src/test/java/org/apache/commons/dbcp2/TestPoolingConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPoolingConnection.java
@@ -16,21 +16,21 @@
  */
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import org.apache.commons.pool2.KeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestPoolingConnection {
 
     private PoolingConnection con = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         con = new PoolingConnection(new TesterConnection("test", "test"));
         final GenericKeyedObjectPoolConfig<DelegatingPreparedStatement> config = new GenericKeyedObjectPoolConfig<>();
@@ -44,7 +44,7 @@ public class TestPoolingConnection {
         con.setStatementPool(stmtPool);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         con.close();
         con = null;

--- a/src/test/java/org/apache/commons/dbcp2/TestPoolingDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPoolingDataSource.java
@@ -17,19 +17,19 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Connection;
 import java.util.Properties;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for PoolingDataSource
@@ -44,7 +44,7 @@ public class TestPoolingDataSource extends TestConnectionPool {
     protected PoolingDataSource<PoolableConnection> ds = null;
     private GenericObjectPool<PoolableConnection> pool = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final Properties props = new Properties();
         props.setProperty("user", "userName");
@@ -66,7 +66,7 @@ public class TestPoolingDataSource extends TestConnectionPool {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         ds.close();
         super.tearDown();
@@ -85,8 +85,8 @@ public class TestPoolingDataSource extends TestConnectionPool {
         // Grab a new connection - should get c[0]'s closed connection
         // so should be delegate-equivalent
         final Connection con = newConnection();
-        Assert.assertNotEquals(c[0], con);
-        Assert.assertEquals(
+        Assertions.assertNotEquals(c[0], con);
+        Assertions.assertEquals(
                 ((DelegatingConnection<?>) c[0]).getInnermostDelegateInternal(),
                 ((DelegatingConnection<?>) con).getInnermostDelegateInternal());
         for (final Connection element : c) {

--- a/src/test/java/org/apache/commons/dbcp2/TestPoolingDriver.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPoolingDriver.java
@@ -17,11 +17,11 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -36,10 +36,10 @@ import javax.sql.DataSource;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for a  {@link GenericObjectPool} based {@link PoolingDriver}.
@@ -53,7 +53,7 @@ public class TestPoolingDriver extends TestConnectionPool {
 
     private PoolingDriver driver = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DriverConnectionFactory cf = new DriverConnectionFactory(new TesterDriver(),"jdbc:apache:commons:testdriver",null);
 
@@ -84,7 +84,7 @@ public class TestPoolingDriver extends TestConnectionPool {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         driver.closePool("test");
         super.tearDown();
@@ -101,7 +101,7 @@ public class TestPoolingDriver extends TestConnectionPool {
                 new GenericObjectPool<>(pcf);
         pcf.setPool(connectionPool);
         final DataSource ds = new PoolingDataSource<>(connectionPool);
-        Assert.assertNotNull(ds);
+        Assertions.assertNotNull(ds);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/dbcp2/TestUtils.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestUtils.java
@@ -19,7 +19,7 @@ package org.apache.commons.dbcp2;
 
 import java.sql.Connection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUtils {
 

--- a/src/test/java/org/apache/commons/dbcp2/cpdsadapter/TestDriverAdapterCPDS.java
+++ b/src/test/java/org/apache/commons/dbcp2/cpdsadapter/TestDriverAdapterCPDS.java
@@ -17,12 +17,13 @@
 
 package org.apache.commons.dbcp2.cpdsadapter;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Properties;
 import java.io.PrintWriter;
@@ -38,9 +39,9 @@ import javax.naming.StringRefAddr;
 import javax.sql.DataSource;
 
 import org.apache.commons.dbcp2.datasources.SharedPoolDataSource;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for DriverAdapterCPDS
@@ -49,7 +50,7 @@ public class TestDriverAdapterCPDS {
 
     private DriverAdapterCPDS pcds;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         pcds = new DriverAdapterCPDS();
         pcds.setDriver("org.apache.commons.dbcp2.TesterDriver");
@@ -169,12 +170,12 @@ public class TestDriverAdapterCPDS {
         assertEquals("bar", pcds.getConnectionProperties().getProperty("password"));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testSetConnectionPropertiesConnectionCalled() throws Exception {
         final Properties properties = new Properties();
         // call to the connection
         pcds.getPooledConnection().close();
-        pcds.setConnectionProperties(properties);
+        assertThrows(IllegalStateException.class, () -> pcds.setConnectionProperties(properties));
     }
 
     @Test
@@ -268,7 +269,7 @@ public class TestDriverAdapterCPDS {
 
         for (int i = 0; i < threads.length; i++) {
             threads[i].join();
-            Assert.assertFalse("Thread " + i + " has failed",threads[i].isFailed());
+            Assertions.assertFalse(threads[i].isFailed(), "Thread " + i + " has failed");
         }
     }
 
@@ -301,9 +302,9 @@ public class TestDriverAdapterCPDS {
         }
     }
 
-    @Test(expected=SQLFeatureNotSupportedException.class)
-    public void testGetParentLogger() throws SQLFeatureNotSupportedException {
-        pcds.getParentLogger();
+    @Test
+    public void testGetParentLogger() {
+        assertThrows(SQLFeatureNotSupportedException.class, pcds::getParentLogger);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestCPDSConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestCPDSConnectionFactory.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -28,8 +28,8 @@ import javax.sql.PooledConnection;
 
 import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
 import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -37,7 +37,7 @@ public class TestCPDSConnectionFactory {
 
     protected ConnectionPoolDataSourceProxy cpds = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         cpds = new ConnectionPoolDataSourceProxy(new DriverAdapterCPDS());
         final DriverAdapterCPDS delegate = (DriverAdapterCPDS) cpds.getDelegate();

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestFactory.java
@@ -17,7 +17,7 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Hashtable;
 
@@ -29,7 +29,7 @@ import javax.naming.Reference;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  */

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestInstanceKeyDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestInstanceKeyDataSource.java
@@ -17,12 +17,13 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.PrintWriter;
 import java.sql.Connection;
@@ -30,9 +31,9 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -46,7 +47,7 @@ public class TestInstanceKeyDataSource {
     private final static String USER = "foo";
     private final static String PASS = "bar";
 
-    @Before
+    @BeforeEach
     public void setUp() throws ClassNotFoundException {
         pcds = new DriverAdapterCPDS();
         pcds.setDriver(DRIVER);
@@ -58,7 +59,7 @@ public class TestInstanceKeyDataSource {
         spds.setConnectionPoolDataSource(pcds);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         spds.close();
     }
@@ -102,16 +103,16 @@ public class TestInstanceKeyDataSource {
         assertEquals(pcds, spds.getConnectionPoolDataSource());
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testConnectionPoolDataSourceAlreadySet() {
-        spds.setConnectionPoolDataSource(new DriverAdapterCPDS());
+        assertThrows(IllegalStateException.class, () -> spds.setConnectionPoolDataSource(new DriverAdapterCPDS()));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testConnectionPoolDataSourceAlreadySetUsingJndi() {
         spds = new SharedPoolDataSource();
         spds.setDataSourceName("anything");
-        spds.setConnectionPoolDataSource(new DriverAdapterCPDS());
+        assertThrows(IllegalStateException.class, () -> spds.setConnectionPoolDataSource(new DriverAdapterCPDS()));
     }
 
     @Test
@@ -122,16 +123,16 @@ public class TestInstanceKeyDataSource {
         assertEquals("anything", spds.getDataSourceName());
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testDataSourceNameAlreadySet() {
-        spds.setDataSourceName("anything");
+        assertThrows(IllegalStateException.class, () -> spds.setDataSourceName("anything"));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testDataSourceNameAlreadySetUsingJndi() {
         spds = new SharedPoolDataSource();
         spds.setDataSourceName("anything");
-        spds.setDataSourceName("anything");
+        assertThrows(IllegalStateException.class, () -> spds.setDataSourceName("anything"));
     }
 
     @Test
@@ -141,10 +142,10 @@ public class TestInstanceKeyDataSource {
         assertEquals(Connection.TRANSACTION_READ_COMMITTED, spds.getDefaultTransactionIsolation());
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testDefaultTransactionIsolationInvalid() {
         assertEquals(InstanceKeyDataSource.UNKNOWN_TRANSACTIONISOLATION, spds.getDefaultTransactionIsolation());
-        spds.setDefaultTransactionIsolation(Integer.MAX_VALUE);
+        assertThrows(IllegalArgumentException.class, () -> spds.setDefaultTransactionIsolation(Integer.MAX_VALUE));
     }
 
     @Test
@@ -153,9 +154,9 @@ public class TestInstanceKeyDataSource {
         assertEquals("anything", spds.getDescription());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testJndiNullProperties() {
-        spds.setJndiEnvironment(null);
+        assertThrows(NullPointerException.class, () -> spds.setJndiEnvironment(null));
     }
 
     @Test
@@ -210,11 +211,11 @@ public class TestInstanceKeyDataSource {
         assertEquals("anything", spds.getValidationQuery());
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testValidationQueryWithConnectionCalled() throws SQLException {
         spds.getConnection();
         assertNull(spds.getValidationQuery());
-        spds.setValidationQuery("anything");
+        assertThrows(IllegalStateException.class, () -> spds.setValidationQuery("anything"));
     }
 
     @Test
@@ -231,12 +232,11 @@ public class TestInstanceKeyDataSource {
         assertEquals(true, spds.isRollbackAfterValidation());
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testRollbackAfterValidationWithConnectionCalled() throws SQLException {
         spds.getConnection();
         assertFalse(spds.isRollbackAfterValidation());
-        spds.setRollbackAfterValidation(true);
-        assertEquals(true, spds.isRollbackAfterValidation());
+        assertThrows(IllegalStateException.class, () -> spds.setRollbackAfterValidation(true));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestKeyedCPDSConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestKeyedCPDSConnectionFactory.java
@@ -17,9 +17,9 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -29,8 +29,8 @@ import javax.sql.PooledConnection;
 import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
 import org.apache.commons.pool2.KeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -38,7 +38,7 @@ public class TestKeyedCPDSConnectionFactory {
 
     protected ConnectionPoolDataSourceProxy cpds = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         cpds = new ConnectionPoolDataSourceProxy(new DriverAdapterCPDS());
         final DriverAdapterCPDS delegate = (DriverAdapterCPDS) cpds.getDelegate();

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestPerUserPoolDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestPerUserPoolDataSource.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -39,9 +39,9 @@ import javax.sql.DataSource;
 import org.apache.commons.dbcp2.TestConnectionPool;
 import org.apache.commons.dbcp2.TesterDriver;
 import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -56,7 +56,7 @@ public class TestPerUserPoolDataSource extends TestConnectionPool {
 
     private DataSource ds;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         user = "foo";
         final DriverAdapterCPDS pcds = new DriverAdapterCPDS();
@@ -79,7 +79,7 @@ public class TestPerUserPoolDataSource extends TestConnectionPool {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         super.tearDown();
         ((PerUserPoolDataSource) ds).close();
@@ -527,12 +527,12 @@ public class TestPerUserPoolDataSource extends TestConnectionPool {
         try {
             final Connection con4 = ds.getConnection(user, "bay"); // new password
             // Idle instances with old password should have been cleared
-            assertEquals("Should be no idle connections in the pool",
-                    0, ((PerUserPoolDataSource) ds).getNumIdle(user));
+            assertEquals(0, ((PerUserPoolDataSource) ds).getNumIdle(user),
+                    "Should be no idle connections in the pool");
             con4.close();
             // Should be one idle instance with new pwd
-            assertEquals("Should be one idle connection in the pool",
-                    1, ((PerUserPoolDataSource) ds).getNumIdle(user));
+            assertEquals(1, ((PerUserPoolDataSource) ds).getNumIdle(user),
+                    "Should be one idle connection in the pool");
             try (Connection c = ds.getConnection(user, "bar")) { // old password
                 fail("Should have generated SQLException");
             } catch (final SQLException expected) {
@@ -540,8 +540,8 @@ public class TestPerUserPoolDataSource extends TestConnectionPool {
             final Connection con5 = ds.getConnection(user, "bay"); // take the idle one
             con3.close(); // Return a connection with the old password
             ds.getConnection(user, "bay").close();  // will try bad returned connection and destroy it
-            assertEquals("Should be one idle connection in the pool",
-                    1, ((PerUserPoolDataSource) ds).getNumIdle(user));
+            assertEquals(1, ((PerUserPoolDataSource) ds).getNumIdle(user),
+                    "Should be one idle connection in the pool");
             con5.close();
         } finally {
             TesterDriver.addUser(user,"bar");

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestPoolKey.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestPoolKey.java
@@ -17,11 +17,11 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for PoolKey.
@@ -32,7 +32,7 @@ public class TestPoolKey {
     private PoolKey poolKey;
     private PoolKey anotherPoolKey;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         poolKey = new PoolKey("ds", "user");
         anotherPoolKey = new PoolKey(null, null);

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestSharedPoolDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestSharedPoolDataSource.java
@@ -17,10 +17,10 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -36,8 +36,8 @@ import org.apache.commons.dbcp2.DelegatingStatement;
 import org.apache.commons.dbcp2.TestConnectionPool;
 import org.apache.commons.dbcp2.TesterDriver;
 import org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -51,7 +51,7 @@ public class TestSharedPoolDataSource extends TestConnectionPool {
     private DriverAdapterCPDS pcds;
     private DataSource ds;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         pcds = new DriverAdapterCPDS();
         pcds.setDriver("org.apache.commons.dbcp2.TesterDriver");
@@ -697,12 +697,12 @@ public class TestSharedPoolDataSource extends TestConnectionPool {
         TesterDriver.addUser("foo","bay"); // change the user/password setting
         try (Connection con4 = ds.getConnection("foo", "bay")) { // new password
             // Idle instances with old password should have been cleared
-            assertEquals("Should be no idle connections in the pool",
-                   0, ((SharedPoolDataSource) ds).getNumIdle());
+            assertEquals(0, ((SharedPoolDataSource) ds).getNumIdle(),
+                    "Should be no idle connections in the pool");
             con4.close();
             // Should be one idle instance with new pwd
-            assertEquals("Should be one idle connection in the pool",
-                    1, ((SharedPoolDataSource) ds).getNumIdle());
+            assertEquals(1, ((SharedPoolDataSource) ds).getNumIdle(),
+                    "Should be one idle connection in the pool");
             try (Connection con4b = ds.getConnection("foo", "bar")) { // old password
                 fail("Should have generated SQLException");
             } catch (final SQLException expected) {
@@ -710,8 +710,8 @@ public class TestSharedPoolDataSource extends TestConnectionPool {
             final Connection con5 = ds.getConnection("foo", "bay"); // take the idle one
             con3.close(); // Return a connection with the old password
             ds.getConnection("foo", "bay").close();  // will try bad returned connection and destroy it
-            assertEquals("Should be one idle connection in the pool",
-                    1, ((SharedPoolDataSource) ds).getNumIdle());
+            assertEquals(1, ((SharedPoolDataSource) ds).getNumIdle(),
+                    "Should be one idle connection in the pool");
             con5.close();
         } finally {
             TesterDriver.addUser("foo","bar");

--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestUserPassKey.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestUserPassKey.java
@@ -17,15 +17,15 @@
 
 package org.apache.commons.dbcp2.datasources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
 import org.apache.commons.dbcp2.Utils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for UserPassKey.
@@ -36,7 +36,7 @@ public class TestUserPassKey {
     private UserPassKey userPassKey;
     private UserPassKey anotherUserPassKey;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         userPassKey = new UserPassKey("user", "pass");
         anotherUserPassKey = new UserPassKey((String) null, "");

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestBasicManagedDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestBasicManagedDataSource.java
@@ -24,7 +24,7 @@ import org.apache.commons.dbcp2.TestBasicDataSource;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
 import org.h2.Driver;
 import org.h2.jdbcx.JdbcDataSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.XADataSource;
 import javax.transaction.Synchronization;
@@ -34,10 +34,11 @@ import javax.transaction.xa.XAException;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * TestSuite for BasicManagedDataSource
@@ -98,10 +99,10 @@ public class TestBasicManagedDataSource extends TestBasicDataSource {
         }
     }
 
-    @Test(expected=SQLException.class)
+    @Test
     public void testTransactionManagerNotSet() throws SQLException {
         try (final BasicManagedDataSource basicManagedDataSource = new BasicManagedDataSource()) {
-            basicManagedDataSource.createConnectionFactory();
+            assertThrows(SQLException.class, basicManagedDataSource::createConnectionFactory);
         }
     }
 
@@ -135,7 +136,7 @@ public class TestBasicManagedDataSource extends TestBasicDataSource {
         }
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testRuntimeExceptionsAreRethrown() throws SQLException, XAException {
         try (final BasicManagedDataSource basicManagedDataSource = new BasicManagedDataSource()) {
             basicManagedDataSource.setTransactionManager(new TransactionManagerImpl());
@@ -145,7 +146,7 @@ public class TestBasicManagedDataSource extends TestBasicDataSource {
             basicManagedDataSource.setPassword("password");
             basicManagedDataSource.setMaxIdle(1);
             // results in a NPE
-            basicManagedDataSource.createPoolableConnectionFactory(null);
+            assertThrows(NullPointerException.class, () -> basicManagedDataSource.createPoolableConnectionFactory(null));
         }
     }
 

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestConnectionWithNarayana.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestConnectionWithNarayana.java
@@ -17,7 +17,7 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -28,10 +28,10 @@ import java.sql.Timestamp;
 import javax.transaction.RollbackException;
 import javax.transaction.Status;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
@@ -62,7 +62,7 @@ public class TestConnectionWithNarayana {
 
     private BasicManagedDataSource mds;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         jtaPropertyManager.getJTAEnvironmentBean().setLastResourceOptimisationInterfaceClassName(
                 "org.apache.commons.dbcp2.managed.LocalXAConnectionFactory$LocalXAResource");
@@ -120,7 +120,7 @@ public class TestConnectionWithNarayana {
         } finally {
             mds.getTransactionManager().rollback();
         }
-        Assert.assertEquals(0, mds.getNumActive());
+        Assertions.assertEquals(0, mds.getNumActive());
     }
 
     @Test
@@ -138,12 +138,12 @@ public class TestConnectionWithNarayana {
                 fail("Should not work after timeout");
             } catch (final SQLException e) {
                 // Expected
-                Assert.assertEquals("Commit can not be set while enrolled in a transaction", e.getMessage());
+                Assertions.assertEquals("Commit can not be set while enrolled in a transaction", e.getMessage());
             }
             mds.getTransactionManager().rollback();
         }
 
-        Assert.assertEquals(0, mds.getNumActive());
+        Assertions.assertEquals(0, mds.getNumActive());
     }
 
     @Test
@@ -218,11 +218,11 @@ public class TestConnectionWithNarayana {
                     conn.close();
                 }
             }
-            Assert.assertEquals(0, mds.getNumActive());
+            Assertions.assertEquals(0, mds.getNumActive());
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         final Connection conn = mds.getConnection();
         final PreparedStatement ps = conn.prepareStatement(DROP_STMT);

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestDataSourceXAConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestDataSourceXAConnectionFactory.java
@@ -17,7 +17,7 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -32,8 +32,8 @@ import javax.sql.XADataSource;
 
 import org.apache.commons.dbcp2.TestBasicDataSource;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for BasicManagedDataSource when using a
@@ -46,7 +46,7 @@ public class TestDataSourceXAConnectionFactory extends TestBasicDataSource {
     public AtomicInteger closeCounter = new AtomicInteger();
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         bmds = new BasicManagedDataSource();

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestLocalXaResource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestLocalXaResource.java
@@ -17,10 +17,11 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.Array;
 import java.sql.Blob;
@@ -45,8 +46,8 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for LocalXAConnectionFactory$LocalXAResource
@@ -56,7 +57,7 @@ public class TestLocalXaResource {
     private Connection conn;
     private LocalXAConnectionFactory.LocalXAResource resource;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         conn = new TestConnection();
         resource = new LocalXAConnectionFactory.LocalXAResource(conn);
@@ -78,22 +79,22 @@ public class TestLocalXaResource {
         assertFalse(resource.isSameRM(new LocalXAConnectionFactory.LocalXAResource(conn)));
     }
 
-    @Test(expected=XAException.class)
-    public void testStartInvalidFlag() throws XAException {
+    @Test
+    public void testStartInvalidFlag() {
         // currently, valid values are TMNOFLAGS and TMRESUME
-        resource.start(null, XAResource.TMENDRSCAN);
+        assertThrows(XAException.class, () -> resource.start(null, XAResource.TMENDRSCAN));
     }
 
-    @Test(expected=XAException.class)
+    @Test
     public void testStartNoFlagButAlreadyEnlisted() throws XAException {
         resource.start(new TestXid(), XAResource.TMNOFLAGS);
-        resource.start(new TestXid(), XAResource.TMNOFLAGS);
+        assertThrows(XAException.class, () -> resource.start(new TestXid(), XAResource.TMNOFLAGS));
     }
 
-    @Test(expected=XAException.class)
+    @Test
     public void testStartNoFlagResumeButDifferentXid() throws XAException {
         resource.start(new TestXid(), XAResource.TMNOFLAGS);
-        resource.start(new TestXid(), XAResource.TMRESUME);
+        assertThrows(XAException.class, () -> resource.start(new TestXid(), XAResource.TMRESUME));
     }
 
     @Test
@@ -114,22 +115,22 @@ public class TestLocalXaResource {
         assertEquals(xid, resource.getXid());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testStartNoFlagResumeEndMissingXid() throws XAException {
         final Xid xid = new TestXid();
         resource.start(xid, XAResource.TMNOFLAGS);
         resource.start(xid, XAResource.TMRESUME);
         // flag is never used in the end
-        resource.end(null, 0);
+        assertThrows(NullPointerException.class, () -> resource.end(null, 0));
     }
 
-    @Test(expected=XAException.class)
+    @Test
     public void testStartNoFlagResumeEndDifferentXid() throws XAException {
         final Xid xid = new TestXid();
         resource.start(xid, XAResource.TMNOFLAGS);
         resource.start(xid, XAResource.TMRESUME);
         // flag is never used in the end
-        resource.end(new TestXid(), 0);
+        assertThrows(XAException.class, () -> resource.end(new TestXid(), 0));
     }
 
     @Test
@@ -209,41 +210,41 @@ public class TestLocalXaResource {
         assertFalse(conn.getAutoCommit());
     }
 
-    @Test(expected=XAException.class)
-    public void testStartFailsWhenCannotSetAutoCommit() throws XAException, SQLException {
+    @Test
+    public void testStartFailsWhenCannotSetAutoCommit() {
         final Xid xid = new TestXid();
         ((TestConnection) conn).throwWhenSetAutoCommit = true;
-        resource.start(xid, XAResource.TMNOFLAGS);
+        assertThrows(XAException.class, () -> resource.start(xid, XAResource.TMNOFLAGS));
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testCommitMissingXid() throws SQLException, XAException {
-        resource.commit(null, false);
+    @Test
+    public void testCommitMissingXid() {
+        assertThrows(NullPointerException.class, () -> resource.commit(null, false));
     }
 
-    @Test(expected=XAException.class)
-    public void testCommitNoTransaction() throws SQLException, XAException {
+    @Test
+    public void testCommitNoTransaction() throws SQLException {
         ((TestConnection) conn).closed = false;
         conn.setReadOnly(false);
-        resource.commit(new TestXid(), false);
+        assertThrows(XAException.class, () -> resource.commit(new TestXid(), false));
     }
 
-    @Test(expected=XAException.class)
+    @Test
     public void testCommitInvalidXid() throws SQLException, XAException {
         final Xid xid = new TestXid();
         ((TestConnection) conn).closed = false;
         conn.setReadOnly(false);
         resource.start(xid, XAResource.TMNOFLAGS);
-        resource.commit(new TestXid(), false);
+        assertThrows(XAException.class, () -> resource.commit(new TestXid(), false));
     }
 
-    @Test(expected=XAException.class)
+    @Test
     public void testCommitConnectionClosed() throws SQLException, XAException {
         final Xid xid = new TestXid();
         ((TestConnection) conn).closed = true;
         conn.setReadOnly(false);
         resource.start(xid, XAResource.TMNOFLAGS);
-        resource.commit(xid, false);
+        assertThrows(XAException.class, () -> resource.commit(xid, false));
     }
 
     @Test
@@ -266,18 +267,18 @@ public class TestLocalXaResource {
         assertTrue(((TestConnection) conn).committed);
     }
 
-    @Test(expected=NullPointerException.class)
-    public void testRollbackMissingXid() throws XAException {
-        resource.rollback(null);
+    @Test
+    public void testRollbackMissingXid() {
+        assertThrows(NullPointerException.class, () -> resource.rollback(null));
     }
 
-    @Test(expected=XAException.class)
+    @Test
     public void testRollbackInvalidXid() throws SQLException, XAException {
         final Xid xid = new TestXid();
         ((TestConnection) conn).closed = false;
         conn.setReadOnly(false);
         resource.start(xid, XAResource.TMNOFLAGS);
-        resource.rollback(new TestXid());
+        assertThrows(XAException.class, () -> resource.rollback(new TestXid()));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnection.java
@@ -17,7 +17,7 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Field;
 import java.sql.Connection;
@@ -42,9 +42,9 @@ import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.commons.dbcp2.TesterDriver;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestSuite for ManagedConnection.
@@ -57,7 +57,7 @@ public class TestManagedConnection {
 
     protected TransactionManager transactionManager;
 
-    @Before
+    @BeforeEach
     public void setUp()
         throws Exception {
         // create a GeronimoTransactionManager for testing
@@ -89,7 +89,7 @@ public class TestManagedConnection {
         ds.setAccessToUnderlyingConnectionAllowed(true);
     }
 
-    @After
+    @AfterEach
     public void tearDown()
         throws Exception {
         pool.close();

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSource.java
@@ -17,11 +17,12 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DelegatingConnection;
@@ -33,10 +34,10 @@ import org.apache.commons.dbcp2.TestConnectionPool;
 import org.apache.commons.dbcp2.TesterDriver;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.transaction.TransactionManager;
 
@@ -57,7 +58,7 @@ public class TestManagedDataSource extends TestConnectionPool {
     protected GenericObjectPool<PoolableConnection> pool = null;
     protected TransactionManager transactionManager;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // create a GeronimoTransactionManager for testing
         transactionManager = new TransactionManagerImpl();
@@ -90,7 +91,7 @@ public class TestManagedDataSource extends TestConnectionPool {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         pool.close();
         super.tearDown();
@@ -159,8 +160,8 @@ public class TestManagedDataSource extends TestConnectionPool {
         // Grab a new connection - should get c[0]'s closed connection
         // so should be delegate-equivalent
         final Connection con = newConnection();
-        Assert.assertNotEquals(c[0], con);
-        Assert.assertEquals(
+        Assertions.assertNotEquals(c[0], con);
+        Assertions.assertEquals(
                 ((DelegatingConnection<?>) c[0]).getInnermostDelegateInternal(),
                 ((DelegatingConnection<?>) con).getInnermostDelegateInternal());
         for (final Connection element : c) {
@@ -182,8 +183,8 @@ public class TestManagedDataSource extends TestConnectionPool {
         // Grab a new connection - should get c[0]'s closed connection
         // so should be delegate-equivalent
         final Connection con = newConnection();
-        Assert.assertNotEquals(c[0], con);
-        Assert.assertEquals(
+        Assertions.assertNotEquals(c[0], con);
+        Assertions.assertEquals(
                 ((DelegatingConnection<?>) c[0]).getInnermostDelegateInternal(),
                 ((DelegatingConnection<?>) con).getInnermostDelegateInternal());
         for (final Connection element : c) {
@@ -257,23 +258,23 @@ public class TestManagedDataSource extends TestConnectionPool {
         c2.close();
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testTransactionRegistryNotInitialized() throws Exception {
         try (ManagedDataSource<?> ds = new ManagedDataSource<>(pool, null)) {
-            ds.getConnection();
+            assertThrows(IllegalStateException.class, ds::getConnection);
         }
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testSetTransactionRegistryAlreadySet() {
         final ManagedDataSource<?> managed = (ManagedDataSource<?>) ds;
-        managed.setTransactionRegistry(null);
+        assertThrows(IllegalStateException.class, () -> managed.setTransactionRegistry(null));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void testSetNullTransactionRegistry() throws Exception {
         try (ManagedDataSource<?> ds = new ManagedDataSource<>(pool, null)) {
-            ds.setTransactionRegistry(null);
+            assertThrows(NullPointerException.class, () -> ds.setTransactionRegistry(null));
         }
     }
 

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSourceInTx.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSourceInTx.java
@@ -17,12 +17,12 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -35,10 +35,10 @@ import javax.transaction.Synchronization;
 import javax.transaction.Transaction;
 
 import org.apache.commons.dbcp2.DelegatingConnection;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests ManagedDataSource with an active transaction in progress.
@@ -46,14 +46,14 @@ import org.junit.Test;
 public class TestManagedDataSourceInTx extends TestManagedDataSource {
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         transactionManager.begin();
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (transactionManager.getTransaction() != null) {
             transactionManager.commit();
@@ -86,12 +86,12 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
             conn[i] = newConnection();
             for(int j=0;j<i;j++) {
                 // two connections should be distinct instances
-                Assert.assertNotSame(conn[j], conn[i]);
+                Assertions.assertNotSame(conn[j], conn[i]);
                 // neither should they should be equivalent even though they are
                 // sharing the same underlying connection
-                Assert.assertNotEquals(conn[j], conn[i]);
+                Assertions.assertNotEquals(conn[j], conn[i]);
                 // Check underlying connection is the same
-                Assert.assertEquals(((DelegatingConnection<?>) conn[j]).getInnermostDelegateInternal(),
+                Assertions.assertEquals(((DelegatingConnection<?>) conn[j]).getInnermostDelegateInternal(),
                         ((DelegatingConnection<?>) conn[i]).getInnermostDelegateInternal());
             }
         }
@@ -174,7 +174,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         assertNotNull(conn2);
 
         // shared connections should not have the same hashcode
-        Assert.assertNotEquals(conn1.hashCode(), conn2.hashCode());
+        Assertions.assertNotEquals(conn1.hashCode(), conn2.hashCode());
     }
 
     @Override
@@ -308,11 +308,11 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
 
         final Connection connection = newConnection();
 
-        assertFalse("Connection should be open", connection.isClosed());
+        assertFalse(connection.isClosed(), "Connection should be open");
 
         connection.close();
 
-        assertTrue("Connection should be closed", connection.isClosed());
+        assertTrue(connection.isClosed(), "Connection should be closed");
     }
 
     @Override
@@ -321,7 +321,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         final Connection connection = newConnection();
 
         // auto commit should be off
-        assertFalse("Auto-commit should be disabled", connection.getAutoCommit());
+        assertFalse(connection.getAutoCommit(), "Auto-commit should be disabled");
 
         // attempt to set auto commit
         try {
@@ -332,7 +332,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         }
 
         // make sure it is still disabled
-        assertFalse("Auto-commit should be disabled", connection.getAutoCommit());
+        assertFalse(connection.getAutoCommit(), "Auto-commit should be disabled");
 
         // close connection
         connection.close();
@@ -343,7 +343,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         final Connection connection = newConnection();
 
         // connection should be open
-        assertFalse("Connection should be open", connection.isClosed());
+        assertFalse(connection.isClosed(), "Connection should be open");
 
         // attempt commit directly
         try {
@@ -354,7 +354,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         }
 
         // make sure it is still open
-        assertFalse("Connection should be open", connection.isClosed());
+        assertFalse(connection.isClosed(), "Connection should be open");
 
         // close connection
         connection.close();
@@ -367,7 +367,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         // NOTE: This test class uses connections that are read-only by default
 
         // connection should be read only
-        assertTrue("Connection be read-only", connection.isReadOnly());
+        assertTrue(connection.isReadOnly(), "Connection be read-only");
 
         // attempt to setReadOnly
         try {
@@ -378,7 +378,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         }
 
         // make sure it is still read-only
-        assertTrue("Connection be read-only", connection.isReadOnly());
+        assertTrue(connection.isReadOnly(), "Connection be read-only");
 
         // attempt to setReadonly
         try {
@@ -389,7 +389,7 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         }
 
         // make sure it is still read-only
-        assertTrue("Connection be read-only", connection.isReadOnly());
+        assertTrue(connection.isReadOnly(), "Connection be read-only");
 
         // close connection
         connection.close();
@@ -401,31 +401,31 @@ public class TestManagedDataSourceInTx extends TestManagedDataSource {
         assertFalse(conn.isClosed());
         assertFalse(isClosed(statement));
 
-        assertSame("statement.getConnection() should return the exact same connection instance that was used to create the statement",
-                conn, statement.getConnection());
+        assertSame(conn, statement.getConnection(),
+                "statement.getConnection() should return the exact same connection instance that was used to create the statement");
 
         final ResultSet resultSet = statement.getResultSet();
         assertFalse(isClosed(resultSet));
-        assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                statement, resultSet.getStatement());
+        assertSame(statement, resultSet.getStatement(),
+                "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
 
         final ResultSet executeResultSet = statement.executeQuery("select * from dual");
         assertFalse(isClosed(executeResultSet));
-        assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                statement, executeResultSet.getStatement());
+        assertSame(statement, executeResultSet.getStatement(),
+                "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
 
         final ResultSet keysResultSet = statement.getGeneratedKeys();
         assertFalse(isClosed(keysResultSet));
-        assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                statement, keysResultSet.getStatement());
+        assertSame(statement, keysResultSet.getStatement(),
+                "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
 
         ResultSet preparedResultSet = null;
         if (statement instanceof PreparedStatement) {
             final PreparedStatement preparedStatement = (PreparedStatement) statement;
             preparedResultSet = preparedStatement.executeQuery();
             assertFalse(isClosed(preparedResultSet));
-            assertSame("resultSet.getStatement() should return the exact same statement instance that was used to create the result set",
-                    statement, preparedResultSet.getStatement());
+            assertSame(statement, preparedResultSet.getStatement(),
+                    "resultSet.getStatement() should return the exact same statement instance that was used to create the result set");
         }
 
 

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestPoolableManagedConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestPoolableManagedConnection.java
@@ -18,10 +18,10 @@
 
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -36,9 +36,9 @@ import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.TesterDriver;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for PoolableManagedConnection.
@@ -51,7 +51,7 @@ public class TestPoolableManagedConnection {
     private Connection conn;
     private PoolableManagedConnection poolableManagedConnection;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // create a GeronimoTransactionManager for testing
         transactionManager = new TransactionManagerImpl();
@@ -81,7 +81,7 @@ public class TestPoolableManagedConnection {
         pool.setMaxWaitMillis(100);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws SQLException {
         if (conn != null && !conn.isClosed()) {
             conn.close();

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestSynchronizationOrder.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestSynchronizationOrder.java
@@ -22,9 +22,9 @@ import org.apache.commons.dbcp2.DelegatingConnection;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.TesterClassLoader;
 import org.apache.commons.pool2.impl.GenericObjectPool;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
@@ -48,8 +48,8 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class TestSynchronizationOrder {
 
@@ -119,13 +119,13 @@ public class TestSynchronizationOrder {
         assertTrue(transactionSynchronizationRegistryRegistered);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws SQLException {
         bds.close();
         bmds.close();
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         transactionManager = new TransactionManager() {
 

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestTransactionContext.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestTransactionContext.java
@@ -20,9 +20,11 @@ package org.apache.commons.dbcp2.managed;
 import java.sql.SQLException;
 import javax.transaction.xa.XAResource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
 import org.apache.geronimo.transaction.manager.TransactionImpl;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * TestSuite for TransactionContext
@@ -32,7 +34,7 @@ public class TestTransactionContext {
     /**
      * JIRA: DBCP-428
      */
-    @Test(expected=SQLException.class)
+    @Test
     public void testSetSharedConnectionEnlistFailure() throws Exception {
         final BasicManagedDataSource basicManagedDataSource = new BasicManagedDataSource();
         basicManagedDataSource.setTransactionManager(new TransactionManagerImpl());
@@ -45,7 +47,7 @@ public class TestTransactionContext {
         final UncooperativeTransaction transaction = new UncooperativeTransaction();
         final TransactionContext transactionContext =
                 new TransactionContext(basicManagedDataSource.getTransactionRegistry(), transaction);
-        transactionContext.setSharedConnection(conn);
+        assertThrows(SQLException.class, () -> transactionContext.setSharedConnection(conn));
         basicManagedDataSource.close();
     }
 


### PR DESCRIPTION
This PR follows commons-lang's example and migrates the project to the modern JUnit Jupiter 5.4.1 testing framework.
Since JUnit Jupiter is not backwards compatible to JUnit 4.x, or even JUnit Vintage 5.x, the patch is a tad large, although most of the changes are just cosmetic.

1. Maven changes:
    1. `junit:junit` was replaced with `org.junit.jupiter:junit-jupiter`.
    2. `org.hamcrest:hamcrest-all` was added since JUnit Jupiter no longer bundles Hamcrest with them.

2. Annotations:
   1. `org.junit.jupiter.api.Test` was used as a drop in replacement for `org.juit.Test` without arguments. See 3.ii for handling of the`@Test` annotation with an `expected` argument.
   2. `org.junit.jupiter.api.BeforeEach` was used as an drop in replacement for `org.junit.Before`.
   3. `org.junit.jupiter.api.AfterEach` was used as a drop in replacement for `org.junit.After`.
   4. `org.junit.jupiter.api.BeforeAll` was used as a drop in replacement for `org.junit.BeforeClass`.
   5. `org.junit.jupiter.api.AfterAll` was used as a drop in replacement for `org.junit.AfterClass`.
   6. `org.junit.jupiter.api.Disabled` was used as a drop in replacement for `org.junit.Ignore`.

3. Assertions:
   1. `org.junit.jupiter.api.Assertions`' methods were used as a drop in replacements for `org.junit.Assert`'s methods with the same name in the simple case of an assertion without a message.  In the case of an assertion with a message, `org.junit.jupiter.api.Assertions`' methods were used, but the argument order was changed - `Assert`'s methods take the message as the first argument, while `Assertions`' methods take the message as the last argument.
   2. `org.junit.jupiter.api.Assertions#assertThrows` was used to assert a specific exception was thrown instead of an `org.junit.Test` annotation with an `expected` argument. This technique has a side bonus of making the tests slightly stricter, as now they assert the exception was thrown from a specific line and prevent false posivites where the test's "set-up" code accidentally threw that exception. The `throws` clauses of these methods were cleaned up from exceptions that can no longer be thrown in order to avoid compilation warnings.
   3. `org.hamcrest.MatcherAssert#assertThat` was used as a drop in reaplcement for `org.junit.Assert#assertThat`, as `org.junit.jupiter.api.Assertions` has no equivilent method.