### PR TITLE
Performance Enhancement: Call toArray with Zero Array Size

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -1220,7 +1220,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
     @Override
     public String[] getConnectionInitSqlsAsArray() {
         final Collection<String> result = getConnectionInitSqls();
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     /**

--- a/src/main/java/org/apache/commons/dbcp2/DelegatingStatement.java
+++ b/src/main/java/org/apache/commons/dbcp2/DelegatingStatement.java
@@ -138,7 +138,7 @@ public class DelegatingStatement extends AbandonedTrace implements Statement {
                 // See bug 17301 for what could happen when ResultSets are closed twice.
                 final List<AbandonedTrace> resultSets = getTrace();
                 if (resultSets != null) {
-                    final ResultSet[] set = resultSets.toArray(new ResultSet[resultSets.size()]);
+                    final ResultSet[] set = resultSets.toArray(new ResultSet[0]);
                     for (final ResultSet element : set) {
                         element.close();
                     }

--- a/src/main/java/org/apache/commons/dbcp2/PoolableCallableStatement.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableCallableStatement.java
@@ -125,7 +125,7 @@ public class PoolableCallableStatement extends DelegatingCallableStatement {
         // See DBCP-10 for what could happen when ResultSets are closed twice.
         final List<AbandonedTrace> resultSets = getTrace();
         if (resultSets != null) {
-            final ResultSet[] set = resultSets.toArray(new ResultSet[resultSets.size()]);
+            final ResultSet[] set = resultSets.toArray(new ResultSet[0]);
             for (final ResultSet element : set) {
                 element.close();
             }

--- a/src/main/java/org/apache/commons/dbcp2/PoolablePreparedStatement.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolablePreparedStatement.java
@@ -138,7 +138,7 @@ public class PoolablePreparedStatement<K> extends DelegatingPreparedStatement {
         // See bug 17301 for what could happen when ResultSets are closed twice.
         final List<AbandonedTrace> resultSets = getTrace();
         if (resultSets != null) {
-            final ResultSet[] set = resultSets.toArray(new ResultSet[resultSets.size()]);
+            final ResultSet[] set = resultSets.toArray(new ResultSet[0]);
             for (final ResultSet element : set) {
                 element.close();
             }

--- a/src/main/java/org/apache/commons/dbcp2/PoolingDriver.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolingDriver.java
@@ -135,7 +135,7 @@ public class PoolingDriver implements Driver {
      */
     public synchronized String[] getPoolNames() {
         final Set<String> names = pools.keySet();
-        return names.toArray(new String[names.size()]);
+        return names.toArray(new String[0]);
     }
 
     @Override


### PR DESCRIPTION
toArray should, at least since Java 7, be used with new T[0] instead of size, since it is "faster, safer, and contractually cleaner" (https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_conclusion)

By the way: e.g. DelegatingStatement lines 140-145 seem to contain code where I am unsure whether it will work.
```
                final List<AbandonedTrace> resultSets = getTrace();
                if (resultSets != null) {
                    final ResultSet[] set = resultSets.toArray(new ResultSet[0]);
                    for (final ResultSet element : set) {
                        element.close();
                    }
                    clearTrace();
                }
```
First: AbandonedTrace is not a sub- or superclass of ResultSet.
Second: Transforming it to an Array and afterwards calling .close() makes no sense, iterating directly over the resultSets would make more sense (but is not possible, since static type checking forbids to do so).
Nevertheless, this patch will not change runability of these lines.