### PR TITLE
Close ObjectOutputStream before calling toByteArray on underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/org/apache/commons/dbcp2/datasources/TestPerUserPoolDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/datasources/TestPerUserPoolDataSource.java
@@ -426,8 +426,8 @@ public class TestPerUserPoolDataSource extends TestConnectionPool {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(baos);
         out.writeObject(ds);
-        final byte[] b = baos.toByteArray();
         out.close();
+        final byte[] b = baos.toByteArray();
 
         final ByteArrayInputStream bais = new ByteArrayInputStream(b);
         final ObjectInputStream in = new ObjectInputStream(bais);


### PR DESCRIPTION
When an `ObjectOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `ObjectOutputStream` before invoking the underlying instances's `toByteArray()`. Although in this case it is not strictly necessary because `writeObject` method is invoked right before `toByteArray`, and `writeObject` internally calls `flush`/`drain`. However, it is good practice to call `flush`/`close` explicitly as mentioned, for example, [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request flips the order of `close` and `toytBeArray` methods.