### PR TITLE
DBCP-534 Allow for manual connection eviction

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -1519,6 +1519,15 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
     }
 
     /**
+     * Manually evicts idle connections
+     */
+    public void evict() throws Exception {
+        if (connectionPool != null) {
+            connectionPool.evict();
+        }
+    }
+
+    /**
      * Returns the value of the accessToUnderlyingConnectionAllowed property.
      *
      * @return true if access to the underlying connection is allowed, false otherwise.

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -660,6 +660,34 @@ public class TestBasicDataSource extends TestConnectionPool {
     }
 
     @Test
+    public void testManualConnectionEvict() throws Exception {
+        ds.setMinIdle(0);
+        ds.setMaxIdle(4);
+        ds.setMinEvictableIdleTimeMillis(10);
+        ds.setNumTestsPerEvictionRun(2);
+
+        final Connection ds2 = ds.createDataSource().getConnection();
+        final Connection ds3 = ds.createDataSource().getConnection();
+
+        assertEquals(0, ds.getNumIdle());
+
+        ds2.close();
+        ds3.close();
+
+        // Make sure MinEvictableIdleTimeMillis has elapsed
+        Thread.sleep(100);
+
+        // Ensure no connections evicted by eviction thread
+        assertEquals(2, ds.getNumIdle());
+
+        // Force Eviction
+        ds.evict();
+
+        // Ensure all connections evicted
+        assertEquals(0, ds.getNumIdle());
+    }
+
+    @Test
     public void testMaxConnLifetimeExceeded() throws Exception {
         try {
             StackMessageLog.lock();


### PR DESCRIPTION
Allow users to run eviction by hand, without having, or having to wait for, an eviction thread.
