### PR TITLE
[DBCP-547] Add a ConnectionFactory class name setting for BasicDataSource.createConnectionFactory()

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -1992,7 +1992,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      */
     
     public void setConnectionFactoryClassName(final String connectionFactoryClassName) {
-    	if (connectionFactoryClassName != null && connectionFactoryClassName.trim().length() > 0) {
+    	if ( !isEmpty(connectionFactoryClassName)) {
     		this.connectionFactoryClassName = connectionFactoryClassName;
     	} else {
     		this.connectionFactoryClassName = null; 
@@ -2563,8 +2563,9 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
     	if (connectionFactoryClassName != null) {
             try {
             	Class<?> connectionFactoryFromCCL = Class.forName(connectionFactoryClassName);
-            	return (ConnectionFactory) connectionFactoryFromCCL.getConstructor(Driver.class, String.class, Properties.class)
-            													   .newInstance(driver, url, connectionProperties);
+            	return (ConnectionFactory) connectionFactoryFromCCL
+            			.getConstructor(Driver.class, String.class, Properties.class)
+            			.newInstance(driver, url, connectionProperties);
             } catch (final Exception t) {
                 	final String message = "Cannot load ConnectionFactory class '" + connectionFactoryClassName + "'";
                 	logWriter.println(message);
@@ -2574,5 +2575,37 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
         } else {
         	return new DriverConnectionFactory(driver, url, connectionProperties);
         }
+    }
+    
+    /**
+     * verify empty string (null, length = 0, contains whitespace)
+     * 
+     * @param s
+     * 			string 
+     * @return boolean
+     */
+    private static boolean isEmpty(String s) {
+		s = (s != null) ? s.trim() : s;
+		return isEmpty((CharSequence) s);
+    }
+    
+    /**
+     * verify empty string (null, length = 0, contains whitespace)
+     * 
+     * @param s
+     * 			string 
+     * @return boolean
+     */
+    private static boolean isEmpty(CharSequence c) {
+    	if (c == null) {
+    		return true;
+    	}
+
+    	for (int i = 0, len = c.length() ; i < len ; i++) {
+    		if ( !Character.isWhitespace(c.charAt(i))) {
+    			return false;
+    		}
+    	}
+    	return true;
     }
 }

--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -2584,7 +2584,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * 			string 
      * @return boolean
      */
-    private static boolean isEmpty(String s) {
+    private boolean isEmpty(String s) {
 		s = (s != null) ? s.trim() : s;
 		return isEmpty((CharSequence) s);
     }
@@ -2596,7 +2596,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * 			string 
      * @return boolean
      */
-    private static boolean isEmpty(CharSequence c) {
+    private boolean isEmpty(CharSequence c) {
     	if (c == null) {
     		return true;
     	}

--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSourceFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSourceFactory.java
@@ -87,6 +87,7 @@ public class BasicDataSourceFactory implements ObjectFactory {
     private static final String PROP_VALIDATION_QUERY = "validationQuery";
     private static final String PROP_VALIDATION_QUERY_TIMEOUT = "validationQueryTimeout";
     private static final String PROP_JMX_NAME = "jmxName";
+    private static final String PROP_CONNECTION_FACTORY_CLASS_NAME = "connectionFactoryClassName";
 
     /**
      * The property name for connectionInitSqls. The associated value String must be of the form [query;]*
@@ -141,7 +142,8 @@ public class BasicDataSourceFactory implements ObjectFactory {
             PROP_REMOVE_ABANDONED_TIMEOUT, PROP_LOG_ABANDONED, PROP_ABANDONED_USAGE_TRACKING, PROP_POOL_PREPARED_STATEMENTS,
             PROP_MAX_OPEN_PREPARED_STATEMENTS, PROP_CONNECTION_PROPERTIES, PROP_MAX_CONN_LIFETIME_MILLIS,
             PROP_LOG_EXPIRED_CONNECTIONS, PROP_ROLLBACK_ON_RETURN, PROP_ENABLE_AUTO_COMMIT_ON_RETURN,
-            PROP_DEFAULT_QUERY_TIMEOUT, PROP_FAST_FAIL_VALIDATION, PROP_DISCONNECTION_SQL_CODES, PROP_JMX_NAME };
+            PROP_DEFAULT_QUERY_TIMEOUT, PROP_FAST_FAIL_VALIDATION, PROP_DISCONNECTION_SQL_CODES, PROP_JMX_NAME,
+            PROP_CONNECTION_FACTORY_CLASS_NAME };
 
     /**
      * Obsolete properties from DBCP 1.x. with warning strings suggesting new properties. LinkedHashMap will guarantee
@@ -547,7 +549,14 @@ public class BasicDataSourceFactory implements ObjectFactory {
         if (value != null) {
             dataSource.setDisconnectionSqlCodes(parseList(value, ','));
         }
+        
+        value = properties.getProperty(PROP_CONNECTION_FACTORY_CLASS_NAME);
+        if (value != null) {
+        	dataSource.setConnectionFactoryClassName(value);
+        }
 
+        		  
+        		
         // DBCP-215
         // Trick to make sure that initialSize connections are created
         if (dataSource.getInitialSize() > 0) {

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -17,13 +17,17 @@
 
 package org.apache.commons.dbcp2;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.sql.Connection;
-import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,11 +43,9 @@ import org.apache.commons.logging.LogFactory;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import junit.framework.Assert;
 
 /**
  * TestSuite for BasicDataSource

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import junit.framework.Assert;
 
 /**
  * TestSuite for BasicDataSource
@@ -874,6 +877,42 @@ public class TestBasicDataSource extends TestConnectionPool {
         ds.setLogAbandoned(!original);
         Assertions.assertNotEquals(Boolean.valueOf(original),
                 Boolean.valueOf(ds.getConnectionPool().getLogAbandoned()));
+    }
+    
+    /**
+     * JIRA: DBCP-547
+     * Verify that ConnectionFactory interface in BasicDataSource.createConnectionFactory()
+     */
+    @Test
+    public void testCreateConnectionFactory() throws Exception {
+    	
+    	/** not set ConnectionFactoryClassName */
+    	Properties properties = new Properties();
+        properties.put("initialSize", "1");
+        properties.put("driverClassName", "org.apache.commons.dbcp2.TesterDriver");
+        properties.put("url", "jdbc:apache:commons:testdriver");
+        properties.put("username", "foo");
+        properties.put("password", "bar");
+        BasicDataSource ds = BasicDataSourceFactory.createDataSource(properties);
+        Connection conn = ds.getConnection();
+        assertNotNull(conn);
+        conn.close();
+        ds.close();
+        
+        /** set ConnectionFactoryClassName */
+        properties = new Properties();
+        properties.put("initialSize", "1");
+        properties.put("driverClassName", "org.apache.commons.dbcp2.TesterDriver");
+        properties.put("url", "jdbc:apache:commons:testdriver");
+        properties.put("username", "foo");
+        properties.put("password", "bar");
+        properties.put("connectionFactoryClassName", "org.apache.commons.dbcp2.TestOracleDriverConnectionFactory");
+        ds = BasicDataSourceFactory.createDataSource(properties);
+        conn = ds.getConnection();
+        assertNotNull(conn);
+        
+        conn.close();
+        ds.close();
     }
 }
 

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -908,7 +908,7 @@ public class TestBasicDataSource extends TestConnectionPool {
         properties.put("url", "jdbc:apache:commons:testdriver");
         properties.put("username", "foo");
         properties.put("password", "bar");
-        properties.put("connectionFactoryClassName", "org.apache.commons.dbcp2.TestOracleDriverConnectionFactory");
+        properties.put("connectionFactoryClassName", "org.apache.commons.dbcp2.TesterConnectionFactory");
         ds = BasicDataSourceFactory.createDataSource(properties);
         conn = ds.getConnection();
         assertNotNull(conn);

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -881,7 +881,7 @@ public class TestBasicDataSource extends TestConnectionPool {
     
     /**
      * JIRA: DBCP-547
-     * Verify that ConnectionFactory interface in BasicDataSource.createConnectionFactory()
+     * Verify that ConnectionFactory interface in BasicDataSource.createConnectionFactory().
      */
     @Test
     public void testCreateConnectionFactory() throws Exception {

--- a/src/test/java/org/apache/commons/dbcp2/TestOracleDriverConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestOracleDriverConnectionFactory.java
@@ -85,6 +85,6 @@ public class TestOracleDriverConnectionFactory implements ConnectionFactory {
     }
 
     private void callOracleSetModule(Connection conn) {
-    	// do something
+    	// call oracleSetModule
     }
 }

--- a/src/test/java/org/apache/commons/dbcp2/TestOracleDriverConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestOracleDriverConnectionFactory.java
@@ -1,0 +1,73 @@
+package org.apache.commons.dbcp2;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+
+/**
+ *	Simple ConnectionFactory impl class that use BasicDataSource.createConnectionFactory()
+ */
+
+public class TestOracleDriverConnectionFactory implements ConnectionFactory {
+	private final String connectionString;
+    private final Driver driver;
+    private final Properties properties;
+
+    /**
+     * Constructs a connection factory for a given Driver.
+     *
+     * @param driver
+     *            The Driver.
+     * @param connectString
+     *            The connection string.
+     * @param properties
+     *            The connection properties.
+     */
+    public TestOracleDriverConnectionFactory(final Driver driver, final String connectString, final Properties properties) {
+        this.driver = driver;
+        this.connectionString = connectString;
+        this.properties = properties;
+    }
+
+    @Override
+    public Connection createConnection() throws SQLException {
+        Connection conn = driver.connect(connectionString, properties);
+        callOracleSetModule(conn);
+        return conn;
+    }
+
+    /**
+     * @return The connection String.
+     * @since 2.6.0
+     */
+    public String getConnectionString() {
+        return connectionString;
+    }
+
+    /**
+     * @return The Driver.
+     * @since 2.6.0
+     */
+    public Driver getDriver() {
+        return driver;
+    }
+
+    /**
+     * @return The Properties.
+     * @since 2.6.0
+     */
+    public Properties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName() + " [" + String.valueOf(driver) + ";" + String.valueOf(connectionString) + ";"
+                + String.valueOf(properties) + "]";
+    }
+
+    private void callOracleSetModule(Connection conn) {
+    	// do something
+    }
+}

--- a/src/test/java/org/apache/commons/dbcp2/TestOracleDriverConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestOracleDriverConnectionFactory.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.commons.dbcp2;
 
 import java.sql.Connection;

--- a/src/test/java/org/apache/commons/dbcp2/TesterConnectionFactory.java
+++ b/src/test/java/org/apache/commons/dbcp2/TesterConnectionFactory.java
@@ -23,10 +23,10 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 /**
- *	Simple ConnectionFactory impl class that use BasicDataSource.createConnectionFactory()
+ * Dummy {@link ConnectionFactory} for testing purpose. 
  */
 
-public class TestOracleDriverConnectionFactory implements ConnectionFactory {
+public class TesterConnectionFactory implements ConnectionFactory {
 	private final String connectionString;
     private final Driver driver;
     private final Properties properties;
@@ -41,7 +41,7 @@ public class TestOracleDriverConnectionFactory implements ConnectionFactory {
      * @param properties
      *            The connection properties.
      */
-    public TestOracleDriverConnectionFactory(final Driver driver, final String connectString, final Properties properties) {
+    public TesterConnectionFactory(final Driver driver, final String connectString, final Properties properties) {
         this.driver = driver;
         this.connectionString = connectString;
         this.properties = properties;
@@ -50,13 +50,12 @@ public class TestOracleDriverConnectionFactory implements ConnectionFactory {
     @Override
     public Connection createConnection() throws SQLException {
         Connection conn = driver.connect(connectionString, properties);
-        callOracleSetModule(conn);
+        doSomething(conn);
         return conn;
     }
 
     /**
      * @return The connection String.
-     * @since 2.6.0
      */
     public String getConnectionString() {
         return connectionString;
@@ -64,7 +63,6 @@ public class TestOracleDriverConnectionFactory implements ConnectionFactory {
 
     /**
      * @return The Driver.
-     * @since 2.6.0
      */
     public Driver getDriver() {
         return driver;
@@ -72,7 +70,6 @@ public class TestOracleDriverConnectionFactory implements ConnectionFactory {
 
     /**
      * @return The Properties.
-     * @since 2.6.0
      */
     public Properties getProperties() {
         return properties;
@@ -84,7 +81,7 @@ public class TestOracleDriverConnectionFactory implements ConnectionFactory {
                 + String.valueOf(properties) + "]";
     }
 
-    private void callOracleSetModule(Connection conn) {
-    	// call oracleSetModule
+    private void doSomething(Connection conn) {
+    	// do something
     }
 }


### PR DESCRIPTION
[DBCP-547] Add a ConnectionFactory interface in BasicDataSource.createConnectionFactory()

I think it would be nice better to implement a ConnectionFactory interface in BasicDataSource class.

In my current project, when getting a connection in my program, I call oracleSetModule.
so, i think that after creating connection, call oracleSetModule via connectionFactoryImpl seems to be nice.

This reduces the cost of calling oracleSetModule when calling BasicDataSource.getConnection().