### PR TITLE
[DBCP-567] Use abort rather than close to clean up abandoned connections.

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -428,7 +428,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      */
     private void closeConnectionPool() {
         final GenericObjectPool<?> oldPool = connectionPool;
-        ((PoolableConnectionFactory) connectionPool.getFactory()).close();
         connectionPool = null;
         try {
             if (oldPool != null) {

--- a/src/main/java/org/apache/commons/dbcp2/PoolableConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableConnectionFactory.java
@@ -42,7 +42,7 @@ import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
  *
  * @since 2.0
  */
-public class PoolableConnectionFactory implements PooledObjectFactory<PoolableConnection>, AutoCloseable {
+public class PoolableConnectionFactory implements PooledObjectFactory<PoolableConnection> {
 
     private static final Log log = LogFactory.getLog(PoolableConnectionFactory.class);
 
@@ -133,14 +133,6 @@ public class PoolableConnectionFactory implements PooledObjectFactory<PoolableCo
             Jdbc41Bridge.setSchema(conn, defaultSchema);
         }
         conn.setDefaultQueryTimeout(defaultQueryTimeoutSeconds);
-    }
-
-    /**
-     * @since 2.9.0
-     */
-    @Override
-    public void close() {
-        // no-op
     }
 
     @Override

--- a/src/main/java/org/apache/commons/dbcp2/PoolingDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolingDataSource.java
@@ -77,9 +77,6 @@ public class PoolingDataSource<C extends Connection> implements DataSource, Auto
     @Override
     public void close() throws RuntimeException, SQLException {
         try {
-            if (pool instanceof GenericObjectPool) {
-                ((AutoCloseable) ((GenericObjectPool<?>) pool).getFactory()).close();
-            }
             pool.close();
         } catch (final RuntimeException rte) {
             throw new RuntimeException(Utils.getMessage("pool.close.fail"), rte);


### PR DESCRIPTION
[DBCP-567] Use abort rather than close to clean up abandoned
connections.

Further clean ups post merge of the main PR and secondary PR.