### PR TITLE
Fix StackOverflowError in PoolableConnection.isDisconnectionSqlException

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/PoolableConnection.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableConnection.java
@@ -253,20 +253,41 @@ public class PoolableConnection extends DelegatingConnection<Connection> impleme
      *            SQLException to be examined
      * @return true if the exception signals a disconnection
      */
-    private boolean isDisconnectionSqlException(final SQLException e) {
+    boolean isDisconnectionSqlException(final SQLException e) {
+        boolean fatalException = isFatalException(e);
+        if (!fatalException) {
+            SQLException parentException = e;
+            SQLException nextException = e.getNextException();
+            while(nextException != null && nextException != parentException && !fatalException) {
+                fatalException = isFatalException(nextException);
+                parentException = nextException;
+                nextException = parentException.getNextException();
+            }
+        }
+        return fatalException;
+    }
+
+    /**
+     * Checks the SQLState of the input exception.
+     * <p>
+     * If {@link #disconnectionSqlCodes} has been set, sql states are compared to those in the
+     * configured list of fatal exception codes. If this property is not set, codes are compared against the default
+     * codes in {@link Utils#DISCONNECTION_SQL_CODES} and in this case anything starting with #{link
+     * Utils.DISCONNECTION_SQL_CODE_PREFIX} is considered a disconnection.
+     * </p>
+     *
+     * @param e
+     *            SQLException to be examined
+     * @return true if the exception signals a disconnection
+     */
+    private boolean isFatalException(final SQLException e) {
         boolean fatalException = false;
         final String sqlState = e.getSQLState();
         if (sqlState != null) {
             fatalException = disconnectionSqlCodes == null
-                    ? sqlState.startsWith(Utils.DISCONNECTION_SQL_CODE_PREFIX)
-                            || Utils.DISCONNECTION_SQL_CODES.contains(sqlState)
-                    : disconnectionSqlCodes.contains(sqlState);
-            if (!fatalException) {
-                final SQLException nextException = e.getNextException();
-                if (nextException != null && nextException != e) {
-                    fatalException = isDisconnectionSqlException(e.getNextException());
-                }
-            }
+                ? sqlState.startsWith(Utils.DISCONNECTION_SQL_CODE_PREFIX)
+                || Utils.DISCONNECTION_SQL_CODES.contains(sqlState)
+                : disconnectionSqlCodes.contains(sqlState);
         }
         return fatalException;
     }

--- a/src/test/java/org/apache/commons/dbcp2/TestPoolableConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestPoolableConnection.java
@@ -20,10 +20,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 
+import java.util.List;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -186,5 +190,19 @@ public class TestPoolableConnection {
         }
 
         assertEquals(0, pool.getNumActive(), "The pool should have no active connections");
+    }
+
+    @Test
+    public void testIsDisconnectionSqlExceptionStackOverflow() throws Exception {
+        int maxDeep = 70000;
+        SQLException rootException = new SQLException("Data truncated", "22001");
+        SQLException parentException = rootException;
+        for (int i = 0; i <= maxDeep; i++) {
+            SQLException childException = new SQLException("Data truncated:" + i, "22001");
+            parentException.setNextException(childException);
+            parentException = childException;
+        }
+        final Connection conn = pool.borrowObject();
+        assertEquals(false, ((PoolableConnection)conn).isDisconnectionSqlException(rootException));
     }
 }


### PR DESCRIPTION
If batch size is more than max call stack size, and all statements have nonfatal exception like data truncation, StackOverflowError will appear rather than the real SQLException.

This PR uses `while loop` instead of `recursion` to prevent it.