### PR TITLE
Removes `Duration` from MXBean signature

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -1064,7 +1064,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * @return the maximum permitted duration of a connection.
      * @since 2.10.0
      */
-    @Override
     public Duration getMaxConnDuration() {
         return maxConnDuration;
     }
@@ -1124,7 +1123,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * @return the maxWaitDuration property value.
      * @since 2.10.0
      */
-    @Override
     public synchronized Duration getMaxWaitDuration() {
         return this.maxWaitDuration;
     }
@@ -1149,7 +1147,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * @see #setMinEvictableIdle(Duration)
      * @since 2.10.0
      */
-    @Override
     public synchronized Duration getMinEvictableIdleDuration() {
         return this.minEvictableIdleDuration;
     }
@@ -1327,7 +1324,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * @return Timeout before an abandoned connection can be removed.
      * @since 2.10.0
      */
-    @Override
     public Duration getRemoveAbandonedTimeoutDuration() {
         return abandonedConfig == null ? Duration.ofSeconds(300) : abandonedConfig.getRemoveAbandonedTimeoutDuration();
     }
@@ -1357,7 +1353,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      *         there are minIdle idle connections in the pool
      * @since 2.10.0
      */
-    @Override
     public synchronized Duration getSoftMinEvictableIdleDuration() {
         return softMinEvictableIdleDuration;
     }
@@ -1434,7 +1429,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      * @see #setDurationBetweenEvictionRuns(Duration)
      * @since 2.10.0
      */
-    @Override
     public synchronized Duration getDurationBetweenEvictionRuns() {
         return this.durationBetweenEvictionRuns;
     }
@@ -1488,7 +1482,6 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      *
      * @return the timeout in seconds before connection validation queries fail.
      */
-    @Override
     public Duration getValidationQueryTimeoutDuration() {
         return validationQueryTimeoutDuration;
     }

--- a/src/main/java/org/apache/commons/dbcp2/DataSourceMXBean.java
+++ b/src/main/java/org/apache/commons/dbcp2/DataSourceMXBean.java
@@ -17,7 +17,6 @@
 package org.apache.commons.dbcp2;
 
 import java.sql.SQLException;
-import java.time.Duration;
 
 /**
  * Defines the methods that will be made available via
@@ -139,21 +138,10 @@ public interface DataSourceMXBean {
     boolean getLogExpiredConnections();
 
     /**
-     * See {@link BasicDataSource#getMaxConnDuration()}.
-     *
-     * @return {@link BasicDataSource#getMaxConnDuration()}.
-     * @since 2.10.0
-     */
-    Duration getMaxConnDuration();
-
-    /**
      * See {@link BasicDataSource#getMaxConnLifetimeMillis()}.
      *
      * @return {@link BasicDataSource#getMaxConnLifetimeMillis()}.
-     *
-     * @deprecated Use {@link #getMaxConnDuration()}.
      */
-    @Deprecated
     long getMaxConnLifetimeMillis();
 
     /**
@@ -178,39 +166,17 @@ public interface DataSourceMXBean {
     int getMaxTotal();
 
     /**
-     * See {@link BasicDataSource#getMaxWaitDuration()}.
-     *
-     * @return {@link BasicDataSource#getMaxWaitDuration()}.
-     * @since 2.10.0
-     */
-    Duration getMaxWaitDuration();
-
-    /**
      * See {@link BasicDataSource#getMaxWaitMillis()}.
      *
      * @return {@link BasicDataSource#getMaxWaitMillis()}.
-     *
-     * @deprecated Use {@link #getMaxWaitDuration()}.
      */
-    @Deprecated
     long getMaxWaitMillis();
-
-    /**
-     * See {@link BasicDataSource#getMinEvictableIdleDuration()}.
-     *
-     * @return {@link BasicDataSource#getMinEvictableIdleDuration()}.
-     * @since 2.10.0
-     */
-    Duration getMinEvictableIdleDuration();
 
     /**
      * See {@link BasicDataSource#getMinEvictableIdleTimeMillis()}.
      *
      * @return {@link BasicDataSource#getMinEvictableIdleTimeMillis()}.
-     *
-     * @deprecated Use {@link #getMinEvictableIdleDuration()}.
      */
-    @Deprecated
     long getMinEvictableIdleTimeMillis();
 
     /**
@@ -256,39 +222,17 @@ public interface DataSourceMXBean {
     boolean getRemoveAbandonedOnMaintenance();
 
     /**
-     * See {@link BasicDataSource#getRemoveAbandonedTimeoutDuration()}.
-     *
-     * @return {@link BasicDataSource#getRemoveAbandonedTimeoutDuration()}.
-     * @since 2.10.0
-     */
-    Duration getRemoveAbandonedTimeoutDuration();
-
-    /**
      * See {@link BasicDataSource#getRemoveAbandonedTimeout()}.
      *
      * @return {@link BasicDataSource#getRemoveAbandonedTimeout()}.
-     *
-     * @deprecated Use {@link #getRemoveAbandonedTimeoutDuration()}.
      */
-    @Deprecated
     int getRemoveAbandonedTimeout();
-
-    /**
-     * See {@link BasicDataSource#getSoftMinEvictableIdleDuration()}.
-     *
-     * @return {@link BasicDataSource#getSoftMinEvictableIdleDuration()}.
-     * @since 2.10.0
-     */
-    Duration getSoftMinEvictableIdleDuration();
 
     /**
      * See {@link BasicDataSource#getSoftMinEvictableIdleTimeMillis()}.
      *
      * @return {@link BasicDataSource#getSoftMinEvictableIdleTimeMillis()}.
-     *
-     * @deprecated Use {@link #getSoftMinEvictableIdleDuration()}.
      */
-    @Deprecated
     long getSoftMinEvictableIdleTimeMillis();
 
     /**
@@ -313,20 +257,10 @@ public interface DataSourceMXBean {
     boolean getTestWhileIdle();
 
     /**
-     * See {@link BasicDataSource#getDurationBetweenEvictionRuns()}.
-     *
-     * @return {@link BasicDataSource#getDurationBetweenEvictionRuns()}.
-     * @since 2.10.0
-     */
-    Duration getDurationBetweenEvictionRuns();
-
-    /**
      * See {@link BasicDataSource#getTimeBetweenEvictionRunsMillis()}.
      *
      * @return {@link BasicDataSource#getTimeBetweenEvictionRunsMillis()}.
-     * @deprecated Use {@link #getDurationBetweenEvictionRuns()}.
      */
-    @Deprecated
     long getTimeBetweenEvictionRunsMillis();
 
     /**
@@ -351,21 +285,10 @@ public interface DataSourceMXBean {
     String getValidationQuery();
 
     /**
-     * See {@link BasicDataSource#getValidationQueryTimeoutDuration()}.
-     *
-     * @return {@link BasicDataSource#getValidationQueryTimeoutDuration()}.
-     * @since 2.10.0
-     */
-    Duration getValidationQueryTimeoutDuration();
-
-    /**
      * See {@link BasicDataSource#getValidationQueryTimeout()}.
      *
      * @return {@link BasicDataSource#getValidationQueryTimeout()}.
-     *
-     * @deprecated Use {@link #getValidationQueryTimeoutDuration()}.
      */
-    @Deprecated
     int getValidationQueryTimeout();
 
     /**

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSourceMXBean.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSourceMXBean.java
@@ -17,11 +17,14 @@
 
 package org.apache.commons.dbcp2;
 
-import java.time.Duration;
-
 import static org.junit.jupiter.api.Assertions.assertNull;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import java.time.Duration;
+import javax.management.JMX;
+import javax.management.NotCompliantMBeanException;
 import org.junit.jupiter.api.Test;
+import com.sun.jmx.mbeanserver.Introspector;
 
 /**
  * Tests for BasicDataSourceMXBean.
@@ -101,11 +104,6 @@ public class TestBasicDataSourceMXBean {
         }
 
         @Override
-        public Duration getMaxConnDuration() {
-            return Duration.ZERO;
-        }
-
-        @Override
         public long getMaxConnLifetimeMillis() {
             return 0;
         }
@@ -126,18 +124,8 @@ public class TestBasicDataSourceMXBean {
         }
 
         @Override
-        public Duration getMaxWaitDuration() {
-            return Duration.ZERO;
-        }
-
-        @Override
         public long getMaxWaitMillis() {
             return 0;
-        }
-
-        @Override
-        public Duration getMinEvictableIdleDuration() {
-            return Duration.ZERO;
         }
 
         @Override
@@ -181,18 +169,8 @@ public class TestBasicDataSourceMXBean {
         }
 
         @Override
-        public Duration getRemoveAbandonedTimeoutDuration() {
-            return Duration.ZERO;
-        }
-
-        @Override
         public int getRemoveAbandonedTimeout() {
             return 0;
-        }
-
-        @Override
-        public Duration getSoftMinEvictableIdleDuration() {
-            return Duration.ZERO;
         }
 
         @Override
@@ -216,11 +194,6 @@ public class TestBasicDataSourceMXBean {
         }
 
         @Override
-        public Duration getDurationBetweenEvictionRuns() {
-            return Duration.ZERO;
-        }
-
-        @Override
         public long getTimeBetweenEvictionRunsMillis() {
             return 0;
         }
@@ -238,11 +211,6 @@ public class TestBasicDataSourceMXBean {
         @Override
         public String getValidationQuery() {
             return null;
-        }
-
-        @Override
-        public Duration getValidationQueryTimeoutDuration() {
-            return Duration.ZERO;
         }
 
         @Override
@@ -277,5 +245,19 @@ public class TestBasicDataSourceMXBean {
     @Test
     public void testDefaultSchema() {
         assertNull(bean.getDefaultSchema());
+    }
+
+    /**
+     * Tests if the {@link BasicDataSourceMXBean} interface is a valid MXBean
+     * interface.
+     */
+    @Test
+    public void testMXBeanCompliance() {
+       assertTrue(JMX.isMXBeanInterface(BasicDataSourceMXBean.class));
+       try {
+          Introspector.testComplianceMXBeanInterface(BasicDataSourceMXBean.class);
+       } catch (NotCompliantMBeanException e) {
+          fail(e);
+       }
     }
 }


### PR DESCRIPTION
Unfortunately `Duration` is defined recursively and can not appear in an MXBean signature.

This PR reverts commit 28eb33b5 and adds a test for MXBean compliance.