### PR TITLE
DBCP-589 - Provide Jakarta namespace ready artifact of DBCP2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,37 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>shade-jakarta</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>jakarta</shadedClassifierName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>javax.transaction</pattern>
+                  <shadedPattern>jakarta.transaction</shadedPattern>
+                  <excludes>
+                    <exclude>javax.transaction.xa.**</exclude>
+                  </excludes>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
         <configuration>
           <ignorePathsToDelete>


### PR DESCRIPTION
# What does this PR do?

This PR provides a Jakarta namespace ready artifact of DBCP2 by relocating the related `javax.transcation.*` imports to  `jakarta.transaction.*` and provides a related (attached) artifact with a jakarta classifier to be consumed by user projects.