### PR TITLE
Abort underlying connection of old driver may cause AbstractMethodError.

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/PoolableConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableConnectionFactory.java
@@ -147,7 +147,7 @@ public class PoolableConnectionFactory implements PooledObjectFactory<PoolableCo
     @Override
     public void destroyObject(final PooledObject<PoolableConnection> p, final DestroyMode mode) throws SQLException {
         if (mode == DestroyMode.ABANDONED) {
-            p.getObject().getInnermostDelegate().abort(Runnable::run);
+            p.getObject().abort(Runnable::run);
         } else {
             p.getObject().reallyClose();
         }


### PR DESCRIPTION
Use DelegatingConnection to abort underlying connection, in case of old driver may cause AbstractMethodError.

IN this case, GenericObjectPool.destroy can not deal with AbstractMethodError, when removeAbandonedOnBorrow enabled, connection leak may occur.