### PR TITLE
Upgrade `commons-logging:commons-logging` to version 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
+      <version>1.3.0</version>
     </dependency>
 
     <dependency>
@@ -389,10 +389,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>${surefire.argline}</argLine>
-          <systemPropertyVariables>
-            <!-- Ensure that logging messages can be inspected -->
-            <org.apache.commons.logging.Log>org.apache.commons.dbcp2.StackMessageLog</org.apache.commons.logging.Log>
-          </systemPropertyVariables>
           <excludes>
             <!-- Test support files -->
             <exclude>**/Tester*.java</exclude>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -73,12 +73,13 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="update" dev="ggregory" due-to="Gary Gregory">Update call sites of deprecated APIs from Apache Commons Pool.</action>
       <!-- ADD -->
       <action type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">Add DataSourceMXBean.getUserName() and deprecate getUsername().</action>
-      <!-- UDPATE -->
+      <!-- UPDATE -->
       <action type="update" dev="ggregory" due-to="Gary Gregory, Dependabot">Bump h2 from 2.2.220 to 2.2.224, #308.</action>
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump commons-parent from 60 to 64.</action>
       <action type="update" dev="ggregory" due-to="Dependabot">Bump org.slf4j:slf4j-simple from 2.0.7 to 2.0.9 #301.</action>
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump org.apache.commons:commons-pool2 from 2.11.1 to 2.12.0.</action>
       <action type="update" dev="ggregory" due-to="Gary Gregory">Bump jakarta.transaction:jakarta.transaction-api from 1.3.1 to 1.3.3.</action>
+      <action type="update" dev="pkarwasz" due-to="Piotr P. Karwasz">Bump commons-logging:commons-logging from 1.2 to 1.3.0.</action>
     </release>
     <release version="2.10.0" date="2023-08-28" description="This is a minor release, including bug fixes and enhancements.">
       <!-- FIX -->

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -62,11 +62,6 @@ public class TestBasicDataSource extends TestConnectionPool {
 
     private static final String CATALOG = "test catalog";
 
-    @BeforeAll
-    public static void setUpClass() {
-        // register a custom logger which supports inspection of the log messages
-        LogFactory.getFactory().setAttribute("org.apache.commons.logging.Log", "org.apache.commons.dbcp2.StackMessageLog");
-    }
     protected BasicDataSource ds;
 
     protected BasicDataSource createDataSource() throws Exception {

--- a/src/test/java/org/apache/commons/dbcp2/TestParallelCreationWithNoIdle.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestParallelCreationWithNoIdle.java
@@ -82,12 +82,6 @@ public class TestParallelCreationWithNoIdle  {
     }
     private static final String CATALOG = "test catalog";
 
-    @BeforeAll
-    public static void setUpClass() {
-        // register a custom logger which supports inspection of the log messages
-        LogFactory.getFactory().setAttribute("org.apache.commons.logging.Log", "org.apache.commons.dbcp2.StackMessageLog");
-    }
-
     protected BasicDataSource ds;
 
     @BeforeEach

--- a/src/test/resources/commons-logging.properties
+++ b/src/test/resources/commons-logging.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##
+# Forces a concrete implementation of both `LogFactory` and `Log`.
+org.apache.commons.logging.LogFactory = org.apache.commons.logging.impl.LogFactoryImpl
+org.apache.commons.logging.Log = org.apache.commons.dbcp2.StackMessageLog


### PR DESCRIPTION
This PR upgrades Apache Commons Logging to version 1.3.0.

The upgrade is trivial, except one minor catch: since the test classpath contains SLF4J, JCL prefers it over the legacy implementation.

In order to use the old `StackMessageLog` implementation a `commons-logging.properties` file is necessary (or the equivalent Java system properties).