### PR TITLE
DBCP-595: Connection pool can be exhausted when connections are killed on the DB side

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/PoolableConnection.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableConnection.java
@@ -223,6 +223,10 @@ public class PoolableConnection extends DelegatingConnection<Connection> impleme
     @Override
     protected void handleException(final SQLException e) throws SQLException {
         fatalSqlExceptionThrown |= isFatalException(e);
+        if (fatalSqlExceptionThrown && getDelegate() != null) {
+            getDelegate().close();
+            this.close();
+        }
         super.handleException(e);
     }
 


### PR DESCRIPTION
This commit represents a proposed fix to the exhausted pool issue reported in DBCP-595.