### PR TITLE
chore(javax2jakarta): update transaction api to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
-      <version>1.3.3</version>
+      <version>2.0.1</version>
     </dependency>
 
     <!-- tomcat naming jars for jndi reference tests -->
@@ -239,18 +239,14 @@
 
     <!-- for testing of managed connections -->
     <dependency>
-      <groupId>org.apache.geronimo.modules</groupId>
+      <groupId>org.apache.geronimo.components</groupId>
       <artifactId>geronimo-transaction</artifactId>
-      <version>2.2.1</version>
+      <version>4.0.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
           <artifactId>org.junit.jupiter</artifactId>
           <groupId>junit-jupiter</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -270,7 +266,7 @@
       <groupId>org.jboss.narayana.jta</groupId>
       <artifactId>narayana-jta</artifactId>
       <!-- Versions >= 5.13.0 require Java 11 -->
-      <version>5.12.7.Final</version>
+      <version>6.0.0.Final</version> <!-- there is even a 7.0.0.Final version... -->
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -298,8 +294,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <commons.componentid>dbcp</commons.componentid>
     <commons.rc.version>RC1</commons.rc.version>
     <commons.module.name>org.apache.commons.dbcp2</commons.module.name>
@@ -319,7 +315,7 @@
     <commons.jira.pid>12310469</commons.jira.pid>
     <commons.pool.version>2.12.0</commons.pool.version>
     <!-- See DBCP-445 and DBCP-454 -->
-    <commons.osgi.import>javax.transaction;version="1.1.0",javax.transaction.xa;version="1.1.0";partial=true;mandatory:=partial,*</commons.osgi.import>
+    <commons.osgi.import>jakarta.transaction;version="2.0.1",javax.transaction.xa;version="1.1.0";partial=true;mandatory:=partial,*</commons.osgi.import>
     <commons.japicmp.ignoreMissingClasses>true</commons.japicmp.ignoreMissingClasses>
     <!-- Commons Release Plugin -->
     <commons.bc.version>2.11.0</commons.bc.version>
@@ -448,11 +444,11 @@
             <oldVersionPattern>${commons.bc.version}</oldVersionPattern>
           </parameter>
           <dependencies>
-            <dependency>
-              <groupId>jakarta.transaction</groupId>
-              <artifactId>jakarta.transaction-api</artifactId>
-              <version>1.3.1</version>
-            </dependency>
+          <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>2.0.1</version>
+          </dependency>
           </dependencies>
         </configuration>
       </plugin>    

--- a/src/main/java/org/apache/commons/dbcp2/managed/BasicManagedDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/BasicManagedDataSource.java
@@ -20,8 +20,8 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 import javax.sql.XADataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.dbcp2.ConnectionFactory;

--- a/src/main/java/org/apache/commons/dbcp2/managed/DataSourceXAConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/DataSourceXAConnectionFactory.java
@@ -25,8 +25,8 @@ import javax.sql.ConnectionEventListener;
 import javax.sql.PooledConnection;
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.Utils;

--- a/src/main/java/org/apache/commons/dbcp2/managed/LocalXAConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/LocalXAConnectionFactory.java
@@ -19,13 +19,12 @@ package org.apache.commons.dbcp2.managed;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
-
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import org.apache.commons.dbcp2.ConnectionFactory;
 
 /**

--- a/src/main/java/org/apache/commons/dbcp2/managed/SynchronizationAdapter.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/SynchronizationAdapter.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import javax.transaction.Synchronization;
+import jakarta.transaction.Synchronization;
 
 /**
  * Implements {@link Synchronization} for subclasses.

--- a/src/main/java/org/apache/commons/dbcp2/managed/TransactionContext.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/TransactionContext.java
@@ -21,12 +21,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import javax.transaction.RollbackException;
-import javax.transaction.Status;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 /**

--- a/src/main/java/org/apache/commons/dbcp2/managed/TransactionRegistry.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/TransactionRegistry.java
@@ -22,10 +22,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
 
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.DelegatingConnection;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestBasicManagedDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestBasicManagedDataSource.java
@@ -17,29 +17,23 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-
 import javax.sql.XADataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAException;
 
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.dbcp2.TestBasicDataSource;
 import org.apache.geronimo.transaction.manager.TransactionManagerImpl;
 import org.h2.Driver;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
-
-import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionManagerImple;
-import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple;
 
 /**
  * TestSuite for BasicManagedDataSource

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestConnectionWithNarayana.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestConnectionWithNarayana.java
@@ -26,8 +26,8 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Duration;
 
-import javax.transaction.RollbackException;
-import javax.transaction.Status;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
 
 import org.apache.commons.dbcp2.Utils;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnection.java
@@ -26,13 +26,13 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.ConnectionFactory;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnectionCachedState.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnectionCachedState.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
+import jakarta.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 
 import org.apache.commons.dbcp2.ConnectionFactory;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSource.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.Connection;
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
+import jakarta.transaction.TransactionManager;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.Constants;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSourceInTx.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSourceInTx.java
@@ -32,8 +32,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import javax.transaction.Synchronization;
-import javax.transaction.Transaction;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.Transaction;
 
 import org.apache.commons.dbcp2.DelegatingConnection;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestPoolableManagedConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestPoolableManagedConnection.java
@@ -28,7 +28,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
+import jakarta.transaction.TransactionManager;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.Constants;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestSynchronizationOrder.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestSynchronizationOrder.java
@@ -32,13 +32,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.BasicDataSource;

--- a/src/test/java/org/apache/commons/dbcp2/transaction/TransactionAdapter.java
+++ b/src/test/java/org/apache/commons/dbcp2/transaction/TransactionAdapter.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.dbcp2.transaction;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
 import javax.transaction.xa.XAResource;
 
 /**

--- a/src/test/java/org/apache/commons/dbcp2/transaction/TransactionManagerAdapter.java
+++ b/src/test/java/org/apache/commons/dbcp2/transaction/TransactionManagerAdapter.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.dbcp2.transaction;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.InvalidTransactionException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
 
 /**
  * A TransactionManager adapter.

--- a/src/test/java/org/apache/commons/dbcp2/transaction/TransactionSynchronizationRegistryAdapter.java
+++ b/src/test/java/org/apache/commons/dbcp2/transaction/TransactionSynchronizationRegistryAdapter.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.dbcp2.transaction;
 
-import javax.transaction.Synchronization;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 
 /**
  * A TransactionSynchronizationRegistry adapter.


### PR DESCRIPTION
Update jakarta.transaction:jakarta.transaction-api from 1.3.1 (packages javax.) to 2.0.1 (packages jakarta.)
This requires to update also:
* narayana to a version using jakarta.transaction-api (for tests only)
* geronimo to a version using jakarta.transaction-api (for tests only)

Those packages also needed to update the minimum java version used to 11