### PR TITLE
Add null guards for DelegatingDatabaseMetaData

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/DelegatingDatabaseMetaData.java
+++ b/src/main/java/org/apache/commons/dbcp2/DelegatingDatabaseMetaData.java
@@ -21,6 +21,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
+import java.util.Objects;
 
 /**
  * <p>
@@ -51,8 +52,8 @@ public class DelegatingDatabaseMetaData implements DatabaseMetaData {
      */
     public DelegatingDatabaseMetaData(final DelegatingConnection<?> connection,
             final DatabaseMetaData databaseMetaData) {
-        this.connection = connection;
-        this.databaseMetaData = databaseMetaData;
+        this.connection = Objects.requireNonNull(connection, "connection");
+        this.databaseMetaData = Objects.requireNonNull(databaseMetaData, "databaseMetaData");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/dbcp2/TestDelegatingDatabaseMetaData.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestDelegatingDatabaseMetaData.java
@@ -20,6 +20,7 @@ package org.apache.commons.dbcp2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -767,6 +768,16 @@ public class TestDelegatingDatabaseMetaData {
             delegate.locatorsUpdateCopy();
         } catch (final SQLException e) {}
         verify(obj, times(1)).locatorsUpdateCopy();
+    }
+
+    @Test
+    public void testNullArguments() throws Exception {
+        assertThrows(NullPointerException.class, () -> {
+            new DelegatingDatabaseMetaData(null, null);
+        });
+        assertThrows(NullPointerException.class, () -> {
+            new DelegatingDatabaseMetaData(new DelegatingConnection(null), null);
+        });
     }
 
     @Test


### PR DESCRIPTION
The class `DelegatingDatabaseMetaData` has two `private final` properties, `databaseMetaData` and `connection`. Their values are provided as arguments to the constructor, but are not guarded against `null` which could propagate and cause NPEs at a later arbitrary time.
This commit implements a fail-fast guard against `null` values.