### PR TITLE
Add custom SQL exception eviction override functionality.

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java
@@ -155,6 +155,14 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      */
     private boolean cacheState = true;
 
+
+    /**
+     * The property that allows custom handling of SQL exceptions to determine whether a connection should be
+     * disconnected and evicted from the pool. Implementations of the {@link SQLExceptionOverride} interface can
+     * provide specific logic to decide if a connection should remain in the pool or be removed.
+     */
+    private SQLExceptionOverride sqlExceptionOverride;
+
     /**
      * The instance of the JDBC Driver to use.
      */
@@ -620,6 +628,7 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
             connectionFactory.setDefaultCatalog(defaultCatalog);
             connectionFactory.setDefaultSchema(defaultSchema);
             connectionFactory.setCacheState(cacheState);
+            connectionFactory.setSqlExceptionOverride(sqlExceptionOverride);
             connectionFactory.setPoolStatements(poolPreparedStatements);
             connectionFactory.setClearStatementPoolOnReturn(clearStatementPoolOnReturn);
             connectionFactory.setMaxOpenPreparedStatements(maxOpenPreparedStatements);
@@ -689,6 +698,16 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
     @Override
     public boolean getCacheState() {
         return cacheState;
+    }
+
+    /**
+     * Gets the SQL exception override instance.
+     *
+     * @return The SQL exception override instance.
+     * @since 2.12.1
+     */
+    public SQLExceptionOverride getSqlExceptionOverride() {
+        return sqlExceptionOverride;
     }
 
     /**
@@ -1759,6 +1778,22 @@ public class BasicDataSource implements DataSource, BasicDataSourceMXBean, MBean
      */
     public void setCacheState(final boolean cacheState) {
         this.cacheState = cacheState;
+    }
+
+    /**
+     * Sets the {@link SQLExceptionOverride} to allow custom handling of SQL exceptions.
+     * This can be used to determine whether a connection should be disconnected and evicted
+     * from the pool based on specific SQL exception conditions.
+     *
+     * @param sqlExceptionOverrideClass The new {@link SQLExceptionOverride} implementation
+     * @since 2.12.1
+     */
+    public void setSqlExceptionOverrideClass(Class<? extends SQLExceptionOverride> sqlExceptionOverrideClass) {
+        try {
+            this.sqlExceptionOverride = sqlExceptionOverrideClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to instantiate class " + sqlExceptionOverrideClass.getName(), e);
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/dbcp2/PoolableConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableConnectionFactory.java
@@ -84,6 +84,8 @@ public class PoolableConnectionFactory implements PooledObjectFactory<PoolableCo
 
     private boolean cacheState;
 
+    private SQLExceptionOverride sqlExceptionOverride;
+
     private boolean poolStatements;
 
     private boolean clearStatementPoolOnReturn;
@@ -161,6 +163,16 @@ public class PoolableConnectionFactory implements PooledObjectFactory<PoolableCo
      */
     public boolean getCacheState() {
         return cacheState;
+    }
+
+    /**
+     * Gets the SQL exception override instance.
+     *
+     * @return The SQL exception override instance.
+     * @since 2.12.1
+     */
+    public SQLExceptionOverride getSqlExceptionOverride() {
+        return sqlExceptionOverride;
     }
 
     /**
@@ -466,6 +478,7 @@ public class PoolableConnectionFactory implements PooledObjectFactory<PoolableCo
 
         final PoolableConnection pc = new PoolableConnection(conn, pool, connJmxName, disconnectionSqlCodes, fastFailValidation);
         pc.setCacheState(cacheState);
+        pc.setSqlExceptionOverride(sqlExceptionOverride);
 
         return new DefaultPooledObject<>(pc);
     }
@@ -506,6 +519,18 @@ public class PoolableConnectionFactory implements PooledObjectFactory<PoolableCo
 
     public void setCacheState(final boolean cacheState) {
         this.cacheState = cacheState;
+    }
+
+    /**
+     * Sets the {@link SQLExceptionOverride} to allow custom handling of SQL exceptions.
+     * This can be used to determine whether a connection should be disconnected and evicted
+     * from the pool based on specific SQL exception conditions.
+     *
+     * @param sqlExceptionOverride The new {@link SQLExceptionOverride} implementation
+     * @since 2.12.1
+     */
+    public void setSqlExceptionOverride(SQLExceptionOverride sqlExceptionOverride) {
+        this.sqlExceptionOverride = sqlExceptionOverride;
     }
 
     /**

--- a/src/main/java/org/apache/commons/dbcp2/SQLExceptionOverride.java
+++ b/src/main/java/org/apache/commons/dbcp2/SQLExceptionOverride.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.dbcp2;
+
+import java.sql.SQLException;
+
+/**
+ * The {@code SQLExceptionOverride} interface provides a mechanism for deciding
+ * whether a connection should be disconnected based on a given {@link SQLException}.
+ * Implementations of this interface can provide custom logic to evaluate SQL exceptions
+ * and decide if a connection should be disconnected, overriding the default handling
+ * of commons-dhcp. When this interface is invoked, commons-dhcp has already decided
+ * to evict the connection from the pool.
+ *
+ * @since 2.12.1
+ */
+public interface SQLExceptionOverride {
+
+    /**
+     * Determines whether a connection should be disconnected based on the provided {@link SQLException}.
+     * <p>
+     * The default implementation always returns {@code true}, indicating that the connection should be disconnected.
+     * Override this method to provide custom logic for evaluating SQL exceptions.
+     * </p>
+     *
+     * @param sqlException the {@link SQLException} to evaluate
+     * @return {@code true} if the connection should be disconnected, {@code false} otherwise
+     * @since 2.12.1
+     */
+    default boolean shouldDisconnectConnection(SQLException sqlException) {
+        return true;
+    }
+}

--- a/src/main/java/org/apache/commons/dbcp2/managed/BasicManagedDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/BasicManagedDataSource.java
@@ -137,6 +137,7 @@ public class BasicManagedDataSource extends BasicDataSource {
             connectionFactory.setDefaultCatalog(getDefaultCatalog());
             connectionFactory.setDefaultSchema(getDefaultSchema());
             connectionFactory.setCacheState(getCacheState());
+            connectionFactory.setSqlExceptionOverride(getSqlExceptionOverride());
             connectionFactory.setPoolStatements(isPoolPreparedStatements());
             connectionFactory.setClearStatementPoolOnReturn(isClearStatementPoolOnReturn());
             connectionFactory.setMaxOpenPreparedStatements(getMaxOpenPreparedStatements());

--- a/src/main/java/org/apache/commons/dbcp2/managed/PoolableManagedConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/PoolableManagedConnectionFactory.java
@@ -106,6 +106,7 @@ public class PoolableManagedConnectionFactory extends PoolableConnectionFactory 
         final PoolableManagedConnection pmc = new PoolableManagedConnection(transactionRegistry, conn, getPool(),
                 getDisconnectionSqlCodes(), isFastFailValidation());
         pmc.setCacheState(getCacheState());
+        pmc.setSqlExceptionOverride(getSqlExceptionOverride());
         return new DefaultPooledObject<>(pmc);
     }
 }

--- a/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestBasicDataSource.java
@@ -266,6 +266,26 @@ public class TestBasicDataSource extends TestConnectionPool {
         }
     }
 
+    @Test
+    public void testCreateConnectionFactoryWithSQLExceptionOverride() throws Exception {
+        Properties properties = new Properties();
+        // set ConnectionFactoryClassName
+        properties = new Properties();
+        properties.put("initialSize", "1");
+        properties.put("driverClassName", "org.apache.commons.dbcp2.TesterDriver");
+        properties.put("url", "jdbc:apache:commons:testdriver");
+        properties.put("username", "foo");
+        properties.put("password", "bar");
+        properties.put("connectionFactoryClassName", "org.apache.commons.dbcp2.TesterConnectionFactory");
+        properties.put("sqlExceptionOverrideClassName", "org.apache.commons.dbcp2.TestSQLExceptionOverride");
+        try (BasicDataSource ds = BasicDataSourceFactory.createDataSource(properties)) {
+            assertNotNull(ds.getSqlExceptionOverride());
+            try (Connection conn = ds.getConnection()) {
+                assertNotNull(conn);
+            }
+        }
+    }
+
     /**
      * JIRA: DBCP-547
      * Verify that ConnectionFactory interface in BasicDataSource.createConnectionFactory().

--- a/src/test/java/org/apache/commons/dbcp2/TestSQLExceptionOverride.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestSQLExceptionOverride.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.dbcp2;
+
+/**
+ * Tests {@link SQLExceptionOverride}.
+ */
+public class TestSQLExceptionOverride implements SQLExceptionOverride {
+}


### PR DESCRIPTION
Motivation:

AWS Aurora can produce SQL state codes that indicate non-fatal errors [1]. The current connection pool implementation doesn't handle these gracefully, leading to unnecessary evictions and performance issues. Allowing custom logic for SQL exception handling will give users more control and improve pool stability and efficiency.

[1] https://github.com/awslabs/aws-mysql-jdbc?tab=readme-ov-file#connection-pooling

Modification:

Added a new SQLExceptionOverride interface to allow users to define custom SQL exception handling behaviour.

Result:

This change allows for more precise handling of SQL exceptions, ensuring connections are only evicted when necessary, enhancing overall pool performance and reliability.