### PR TITLE
Avoid object creation when invoking isDisconnectionSqlException.

### DIFF
--- a/src/main/java/org/apache/commons/dbcp2/PoolableConnection.java
+++ b/src/main/java/org/apache/commons/dbcp2/PoolableConnection.java
@@ -268,7 +268,7 @@ public class PoolableConnection extends DelegatingConnection<Connection> impleme
         final String sqlState = e.getSQLState();
         if (sqlState != null) {
             fatalException = disconnectionSqlCodes == null
-                ? sqlState.startsWith(Utils.DISCONNECTION_SQL_CODE_PREFIX) || Utils.getDisconnectionSqlCodes().contains(sqlState)
+                ? sqlState.startsWith(Utils.DISCONNECTION_SQL_CODE_PREFIX) || Utils.isDisconnectionSqlCode(sqlState)
                 : disconnectionSqlCodes.contains(sqlState);
         }
         return fatalException;

--- a/src/main/java/org/apache/commons/dbcp2/Utils.java
+++ b/src/main/java/org/apache/commons/dbcp2/Utils.java
@@ -193,7 +193,7 @@ public final class Utils {
      *
      * @param sqlState the SQL state to check.
      * @return true if the SQL state is a fatal connection error, false otherwise.
-     * @since 2.12.1
+     * @since 2.13.0
      */
     static boolean isDisconnectionSqlCode(String sqlState) {
         return DISCONNECTION_SQL_CODES.contains(sqlState);

--- a/src/main/java/org/apache/commons/dbcp2/Utils.java
+++ b/src/main/java/org/apache/commons/dbcp2/Utils.java
@@ -187,6 +187,17 @@ public final class Utils {
     }
 
     /**
+     * Checks if the given SQL state corresponds to a fatal connection error.
+     *
+     * @param sqlState the SQL state to check.
+     * @return true if the SQL state is a fatal connection error, false otherwise.
+     * @since 2.12.1
+     */
+    static boolean isDisconnectionSqlCode(String sqlState) {
+        return DISCONNECTION_SQL_CODES.contains(sqlState);
+    }
+
+    /**
      * Gets the correct i18n message for the given key.
      *
      * @param key The key to look up an i18n message.

--- a/src/test/java/org/apache/commons/dbcp2/TestUtils.java
+++ b/src/test/java/org/apache/commons/dbcp2/TestUtils.java
@@ -19,6 +19,9 @@ package org.apache.commons.dbcp2;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class TestUtils {
 
     public static PStmtKey getPStmtKey(final PoolablePreparedStatement<PStmtKey> poolablePreparedStatement) {
@@ -28,5 +31,15 @@ public class TestUtils {
     @Test
     public void testClassLoads() {
         Utils.closeQuietly((AutoCloseable) null);
+    }
+
+    @Test
+    public void testIsDisconnectionSqlCode() {
+        assertTrue(Utils.isDisconnectionSqlCode("57P01"), "57P01 should be recognised as a disconnection SQL code.");
+        assertTrue(Utils.isDisconnectionSqlCode("01002"), "01002 should be recognised as a disconnection SQL code.");
+        assertTrue(Utils.isDisconnectionSqlCode("JZ0C0"), "JZ0C0 should be recognised as a disconnection SQL code.");
+
+        assertFalse(Utils.isDisconnectionSqlCode("INVALID"), "INVALID should not be recognised as a disconnection SQL code.");
+        assertFalse(Utils.isDisconnectionSqlCode("00000"), "00000 should not be recognised as a disconnection SQL code.");
     }
 }


### PR DESCRIPTION
Motivation:

By default isDisconnectionSqlException creates a new HashSet every invocation.

Modification:

Added new package-protected method, isDisconnectionSqlCode(String sqlState), that directly checks if a given sqlState is in the internal set.

Result:

The new method improves performance by avoiding redundant object creation.