### PR TITLE
dependabot: ignore dep versions that require Java 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+    ignore:
+      - dependency-name: org.jboss.narayana.jta:narayana-jta
+        versions:
+          # require Java 11
+          - ">= 5.13.0"
+      - dependency-name: org.jboss.logging:jboss-logging
+        versions:
+          # require Java 11
+          - ">= 3.5.0"
+      - dependency-name: com.h2database:h2
+        versions:
+          # require Java 11
+          - ">= 2.3.230"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Replaces:

* https://github.com/apache/commons-dbcp/pull/471
* https://github.com/apache/commons-dbcp/pull/430
* https://github.com/apache/commons-dbcp/pull/419

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
