### PR TITLE
Migrated javax.transaction to jakarta.transaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,19 @@
     <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
-      <version>1.3.3</version>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
+      <version>4.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.interceptor</groupId>
+      <artifactId>jakarta.interceptor-api</artifactId>
+      <version>2.2.0</version>
+      <scope>provided</scope>
     </dependency>
     <!-- tomcat naming jars for jndi reference tests -->
     <dependency>
@@ -102,9 +114,9 @@
     </dependency>
     <!-- for testing of managed connections -->
     <dependency>
-      <groupId>org.apache.geronimo.modules</groupId>
+      <groupId>org.apache.geronimo.components</groupId>
       <artifactId>geronimo-transaction</artifactId>
-      <version>2.2.1</version>
+      <version>4.0.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -133,7 +145,7 @@
       <groupId>org.jboss.narayana.jta</groupId>
       <artifactId>narayana-jta</artifactId>
       <!-- Versions >= 5.13.0 require Java 11 -->
-      <version>5.12.7.Final</version>
+      <version>7.2.1.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/commons/dbcp2/managed/BasicManagedDataSource.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/BasicManagedDataSource.java
@@ -20,8 +20,8 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 import javax.sql.XADataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.dbcp2.ConnectionFactory;

--- a/src/main/java/org/apache/commons/dbcp2/managed/DataSourceXAConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/DataSourceXAConnectionFactory.java
@@ -25,8 +25,8 @@ import javax.sql.ConnectionEventListener;
 import javax.sql.PooledConnection;
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.Utils;

--- a/src/main/java/org/apache/commons/dbcp2/managed/LocalXAConnectionFactory.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/LocalXAConnectionFactory.java
@@ -20,8 +20,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;

--- a/src/main/java/org/apache/commons/dbcp2/managed/SynchronizationAdapter.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/SynchronizationAdapter.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.dbcp2.managed;
 
-import javax.transaction.Synchronization;
+import jakarta.transaction.Synchronization;
 
 /**
  * Implements {@link Synchronization} for subclasses.

--- a/src/main/java/org/apache/commons/dbcp2/managed/TransactionContext.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/TransactionContext.java
@@ -21,12 +21,12 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
 
-import javax.transaction.RollbackException;
-import javax.transaction.Status;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 /**

--- a/src/main/java/org/apache/commons/dbcp2/managed/TransactionRegistry.java
+++ b/src/main/java/org/apache/commons/dbcp2/managed/TransactionRegistry.java
@@ -22,10 +22,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
 
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.DelegatingConnection;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestBasicManagedDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestBasicManagedDataSource.java
@@ -28,8 +28,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 import javax.sql.XADataSource;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAException;
 
 import org.apache.commons.dbcp2.BasicDataSource;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestConnectionWithNarayana.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestConnectionWithNarayana.java
@@ -28,8 +28,8 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Duration;
 
-import javax.transaction.RollbackException;
-import javax.transaction.Status;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
 
 import org.apache.commons.dbcp2.Utils;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnection.java
@@ -26,13 +26,13 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.ConnectionFactory;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnectionCachedState.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedConnectionCachedState.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
+import jakarta.transaction.TransactionManager;
 import javax.transaction.xa.XAException;
 
 import org.apache.commons.dbcp2.ConnectionFactory;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSource.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSource.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.sql.Connection;
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
+import jakarta.transaction.TransactionManager;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.Constants;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSourceInTx.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestManagedDataSourceInTx.java
@@ -33,8 +33,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import javax.transaction.Synchronization;
-import javax.transaction.Transaction;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.Transaction;
 
 import org.apache.commons.dbcp2.DelegatingConnection;
 import org.junit.jupiter.api.AfterEach;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestPoolableManagedConnection.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestPoolableManagedConnection.java
@@ -27,7 +27,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
+import jakarta.transaction.TransactionManager;
 
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.Constants;

--- a/src/test/java/org/apache/commons/dbcp2/managed/TestSynchronizationOrder.java
+++ b/src/test/java/org/apache/commons/dbcp2/managed/TestSynchronizationOrder.java
@@ -33,13 +33,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.xa.XAResource;
 
 import org.apache.commons.dbcp2.BasicDataSource;

--- a/src/test/java/org/apache/commons/dbcp2/transaction/TransactionAdapter.java
+++ b/src/test/java/org/apache/commons/dbcp2/transaction/TransactionAdapter.java
@@ -17,12 +17,12 @@
 
 package org.apache.commons.dbcp2.transaction;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.RollbackException;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
 import javax.transaction.xa.XAResource;
 
 /**

--- a/src/test/java/org/apache/commons/dbcp2/transaction/TransactionManagerAdapter.java
+++ b/src/test/java/org/apache/commons/dbcp2/transaction/TransactionManagerAdapter.java
@@ -17,14 +17,14 @@
 
 package org.apache.commons.dbcp2.transaction;
 
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.InvalidTransactionException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-import javax.transaction.TransactionManager;
+import jakarta.transaction.HeuristicMixedException;
+import jakarta.transaction.HeuristicRollbackException;
+import jakarta.transaction.InvalidTransactionException;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.TransactionManager;
 
 /**
  * A TransactionManager adapter.

--- a/src/test/java/org/apache/commons/dbcp2/transaction/TransactionSynchronizationRegistryAdapter.java
+++ b/src/test/java/org/apache/commons/dbcp2/transaction/TransactionSynchronizationRegistryAdapter.java
@@ -17,8 +17,8 @@
 
 package org.apache.commons.dbcp2.transaction;
 
-import javax.transaction.Synchronization;
-import javax.transaction.TransactionSynchronizationRegistry;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 
 /**
  * A TransactionSynchronizationRegistry adapter.


### PR DESCRIPTION
As part of the migration to `jakarta.transaction-api`, we intend to use `BasicManagedDataSource` with the `jakarta` package instead of `javax`. I haven't seen any activity initiated for this migration, so please consider my pull request as a potential solution for the transition.